### PR TITLE
Updated npm badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ istanbul cover test.js
 [travis-image]: https://travis-ci.org/codecov/codecov-node.svg?branch=master
 [travis-url]: https://travis-ci.org/codecov/codecov-node
 
-[npm-url]: https://npmjs.org/package/codecov.io
-[npm-image]: https://img.shields.io/npm/v/codecov.io.svg
+[npm-url]: https://npmjs.org/package/codecov
+[npm-image]: https://img.shields.io/npm/v/codecov.svg
 
 [depstat-url]: https://david-dm.org/codecov/codecov-node
 [depstat-image]: https://img.shields.io/david/codecov/codecov-node/master.svg


### PR DESCRIPTION
npm badge was using codecov.io npm package. Changed to use new codecov package