### PR TITLE
Replace execSync find commands with globby and add AppVeyor CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,19 @@
+version: 1.0.{build}
+environment:
+  matrix:
+  - NODEJS_VERSION: "4.1"
+  - NODEJS_VERSION: "4"
+  - NODEJS_VERSION: "0.12"
+  - NODEJS_VERSION: "0.11"
+  - NODEJS_VERSION: "0.10"
+  # iojs
+  - NODEJS_VERSION: "1"
+install:
+  - ps: Install-Product node $env:NODEJS_VERSION
+  - npm install
+build:
+  off
+test:
+  off
+test_script:
+  - npm test

--- a/lib/codecov.js
+++ b/lib/codecov.js
@@ -1,4 +1,5 @@
 var fs = require('fs');
+var globby = require('globby');
 var request = require('request');
 var urlgrey = require('urlgrey');
 var execSync = require('child_process').execSync;
@@ -13,66 +14,87 @@ var detectProvider = require('./detect');
 
 var version = "v1.0.1";
 
-var patterns = "-type f \\( -name '*coverage.*' " +
-               "-or -name 'nosetests.xml' " +
-               "-or -name 'jacoco*.xml' " +
-               "-or -name 'clover.xml' " +
-               "-or -name 'report.xml' " +
-               "-or -name 'cobertura.xml' " +
-               "-or -name 'luacov.report.out' " +
-               "-or -name 'lcov.info' " +
-               "-or -name '*.lcov' " +
-               "-or -name 'gcov.info' " +
-               "-or -name '*.gcov' " +
-               "-or -name '*.lst' \\) " +
-               "-not -name '*.sh' " +
-               "-not -name '*.data' " +
-               "-not -name '*.py' " +
-               "-not -name '*.class' " +
-               "-not -name '*.xcconfig' " +
-               "-not -name 'Coverage.profdata' " +
-               "-not -name 'phpunit-code-coverage.xml' " +
-               "-not -name 'coverage.serialized' " +
-               "-not -name '*.pyc' " +
-               "-not -name '*.cfg' " +
-               "-not -name '*.egg' " +
-               "-not -name '*.whl' " +
-               "-not -name '*.html' " +
-               "-not -name '*.js' " +
-               "-not -name '*.cpp' " +
-               "-not -name 'coverage.jade' " +
-               "-not -name 'include.lst' " +
-               "-not -name 'inputFiles.lst' " +
-               "-not -name 'createdFiles.lst' " +
-               "-not -name 'coverage.html' " +
-               "-not -name 'scoverage.measurements.*' " +
-               "-not -name 'test_*_coverage.txt' " +
-               "-not -path '*/vendor/*' " +
-               "-not -path '*/htmlcov/*' " +
-               "-not -path '*/home/cainus/*' " +
-               "-not -path '*/virtualenv/*' " +
-               "-not -path '*/js/generated/coverage/*' " +
-               "-not -path '*/.virtualenv/*' " +
-               "-not -path '*/virtualenvs/*' " +
-               "-not -path '*/.virtualenvs/*' " +
-               "-not -path '*/.env/*' " +
-               "-not -path '*/.envs/*' " +
-               "-not -path '*/env/*' " +
-               "-not -path '*/envs/*' " +
-               "-not -path '*/.venv/*' " +
-               "-not -path '*/.venvs/*' " +
-               "-not -path '*/venv/*' " +
-               "-not -path '*/venvs/*' " +
-               "-not -path '*/.git/*' " +
-               "-not -path '*/.hg/*' " +
-               "-not -path '*/.tox/*' " +
-               "-not -path '*/__pycache__/*' " +
-               "-not -path '*/.egg-info*' " +
-               "-not -path '*/$bower_components/*' " +
-               "-not -path '*/node_modules/*' " +
-               "-not -path '*/conftest_*.c.gcov'";
+/**
+ * Concatenate array of strings by comma
+ * @param patterns Array of strings to join
+ */
+function patternsToString(patterns) {
+  return '{' + patterns.join(',') + '}';
+}
+
+/**
+ * Get arrays of include and excluded files
+ */
+function getPatterns() {
+  return {
+    include: [
+      // include
+      '**/*coverage.*',
+      '**/nosetests.xml',
+      '**/jacoco*.xml',
+      '**/clover.xml',
+      '**/report.xml',
+      '**/cobertura.xml',
+      '**/luacov.report.out',
+      '**/lcov.info',
+      '**/*.lcov',
+      '**/gcov.info',
+      '**/*.gcov',
+      '**/*.lst'
+    ],
 
 
+    // exclude
+    exclude: [
+      '**/*.sh',
+      '**/*.data',
+      '**/*.py',
+      '**/*.class',
+      '**/*.xcconfig',
+      '**/Coverage.profdata',
+      '**/phpunit-code-coverage.xml',
+      '**/coverage.serialized',
+      '**/*.pyc',
+      '**/*.cfg',
+      '**/*.egg',
+      '**/*.whl',
+      '**/*.html',
+      '**/*.js',
+      '**/*.cpp',
+      '**/coverage.jade',
+      '**/include.lst',
+      '**/inputFiles.lst',
+      '**/createdFiles.lst',
+      '**/coverage.html',
+      '**/scoverage.measurements.*',
+      '**/test_*_coverage.txt',
+      '**/vendor/**/*',
+      '**/htmlcov/**/*',
+      '**/home/cainus/**/*',
+      '**/virtualenv/**/*',
+      '**/js/generated/coverage/**/*',
+      '**/.virtualenv/**/*',
+      '**/virtualenvs/**/*',
+      '**/.virtualenvs/**/*',
+      '**/.env/**/*',
+      '**/.envs/**/*',
+      '**/env/**/*',
+      '**/envs/**/*',
+      '**/.venv/**/*',
+      '**/.venvs/**/*',
+      '**/venv/**/*',
+      '**/venvs/**/*',
+      '**/.git/**/*',
+      '**/.hg/**/*',
+      '**/.tox/**/*',
+      '**/__pycache__/**/*',
+      '**/.egg-info*',
+      '**/$bower_components/**/*',
+      '**/node_modules/**/*',
+      '**/conftest_*.c.gcov'
+    ]
+  };
+}
 
 var sendToCodecovV2 = function(codecov_endpoint, query, upload_body, on_success, on_failure){
   // Direct to Codecov
@@ -193,6 +215,7 @@ var upload = function(args, on_success, on_failure){
   console.log(query);
 
   var upload = "";
+  var patterns = getPatterns();
 
   // Add specified env vars
   var env_found = false;
@@ -234,11 +257,12 @@ var upload = function(args, on_success, on_failure){
   }
 
   // Detect .bowerrc
-  var bowerrc = execSync('cd '+root+' && test -f .bowerrc && cat .bowerrc || echo ""').toString().trim(), more_patterns = '';
-  if (bowerrc) {
+  var bowerrc = globby.sync('.bowerrc', { root: root, nosort: true });
+  if (bowerrc.length === 1) {
+    bowerrc = fs.readFileSync(bowerrc[0], 'utf8');
     bowerrc = JSON.parse(bowerrc).directory;
     if (bowerrc) {
-      more_patterns = " -not -path '*/" + bowerrc.toString().replace(/\/$/, '') + "/*'";
+      patterns.exclude.push(bowerrc.toString().replace(/\/$/, '') + '/**/*');
     }
   }
 
@@ -257,7 +281,16 @@ var upload = function(args, on_success, on_failure){
     }
   } else if ((args.options.disable || '').split(',').indexOf('search') === -1) {
     console.log('==> Scanning for reports');
-    var _files = execSync('find ' + root + ' ' + patterns + more_patterns).toString().trim().split('\n');
+    var _files = globby.sync(
+      patternsToString(patterns.include),
+      {
+        cwd : root,
+        nosort: true,
+        nocase: true,
+        ignore: patternsToString(patterns.exclude)
+      }
+    );
+
     if (_files) {
       for (var i2 = _files.length - 1; i2 >= 0; i2--) {
         file = _files[i2];

--- a/package.json
+++ b/package.json
@@ -26,10 +26,11 @@
   },
   "homepage": "https://github.com/codecov/codecov-node",
   "dependencies": {
-    "request": ">=2.42.0",
-    "urlgrey": ">=0.4.0",
     "argv": ">=0.0.2",
-    "execSync": "1.0.2"
+    "execSync": "1.0.2",
+    "globby": "^4.0.0",
+    "request": ">=2.42.0",
+    "urlgrey": ">=0.4.0"
   },
   "devDependencies": {
     "expect.js": "0.3.1",

--- a/test/index.js
+++ b/test/index.js
@@ -24,7 +24,7 @@ describe("Codecov", function(){
 
   it("can get a token passed via env variable", function(){
     process.env.codecov_token = 'abc123';
-    expect(codecov.upload({options: {dump: true}}).query.token).to.eql('abc123');
+    expect(codecov.upload({options: {dump: true, disable: 'search'}}).query.token).to.eql('abc123');
     delete process.env.codecov_token;
     process.env.CODECOV_TOKEN = 'ABC123';
     expect(codecov.upload({options: {dump: true}}).query.token).to.eql('ABC123');


### PR DESCRIPTION
First part of removing execSync dependency as of #8.

Using [globby](https://github.com/sindresorhus/globby) to find files instead of Unix command `find`.
This makes it compatible for Windows environments where the `find` command is not available related to #2.
Added AppVeyor build configuration to run tests on Windows environment as well. This needs to be added to the repository manually. See more on [AppVeyor](http://www.appveyor.com/) and the [current build status on AppVeyor](https://ci.appveyor.com/project/Crevil/codecov-node)

Note that the build breakes on Node 0.10 as of the execSync dependency. The rest uses `child_process.execSync` as by design.