### PR TITLE
de-execSync, Part 1: Refactor

### DIFF
--- a/lib/codecov.js
+++ b/lib/codecov.js
@@ -9,66 +9,75 @@ var root;
 
 var version = "v1.0.1";
 
-var patterns = "-type f \\( -name '*coverage.*' " +
-               "-or -name 'nosetests.xml' " +
-               "-or -name 'jacoco*.xml' " +
-               "-or -name 'clover.xml' " +
-               "-or -name 'report.xml' " +
-               "-or -name 'cobertura.xml' " +
-               "-or -name 'luacov.report.out' " +
-               "-or -name 'lcov.info' " +
-               "-or -name '*.lcov' " +
-               "-or -name 'gcov.info' " +
-               "-or -name '*.gcov' " +
-               "-or -name '*.lst' \\) " +
-               "-not -name '*.sh' " +
-               "-not -name '*.data' " +
-               "-not -name '*.py' " +
-               "-not -name '*.class' " +
-               "-not -name '*.xcconfig' " +
-               "-not -name 'Coverage.profdata' " +
-               "-not -name 'phpunit-code-coverage.xml' " +
-               "-not -name 'coverage.serialized' " +
-               "-not -name '*.pyc' " +
-               "-not -name '*.cfg' " +
-               "-not -name '*.egg' " +
-               "-not -name '*.whl' " +
-               "-not -name '*.html' " +
-               "-not -name '*.js' " +
-               "-not -name '*.cpp' " +
-               "-not -name 'coverage.jade' " +
-               "-not -name 'include.lst' " +
-               "-not -name 'inputFiles.lst' " +
-               "-not -name 'createdFiles.lst' " +
-               "-not -name 'coverage.html' " +
-               "-not -name 'scoverage.measurements.*' " +
-               "-not -name 'test_*_coverage.txt' " +
-               "-not -path '*/vendor/*' " +
-               "-not -path '*/htmlcov/*' " +
-               "-not -path '*/home/cainus/*' " +
-               "-not -path '*/virtualenv/*' " +
-               "-not -path '*/js/generated/coverage/*' " +
-               "-not -path '*/.virtualenv/*' " +
-               "-not -path '*/virtualenvs/*' " +
-               "-not -path '*/.virtualenvs/*' " +
-               "-not -path '*/.env/*' " +
-               "-not -path '*/.envs/*' " +
-               "-not -path '*/env/*' " +
-               "-not -path '*/envs/*' " +
-               "-not -path '*/.venv/*' " +
-               "-not -path '*/.venvs/*' " +
-               "-not -path '*/venv/*' " +
-               "-not -path '*/venvs/*' " +
-               "-not -path '*/.git/*' " +
-               "-not -path '*/.hg/*' " +
-               "-not -path '*/.tox/*' " +
-               "-not -path '*/__pycache__/*' " +
-               "-not -path '*/.egg-info*' " +
-               "-not -path '*/$bower_components/*' " +
-               "-not -path '*/node_modules/*' " +
-               "-not -path '*/conftest_*.c.gcov'";
+var glob = require('glob')
 
+var fileNamePatterns = [
+  '*coverage.*',
+  'nosetests.xml',
+  'jacoco*.xml',
+  'clover.xml',
+  'report.xml',
+  'cobertura.xml',
+  'luacov.report.out',
+  'lcov.info',
+  '*.lcov',
+  'gcov.info',
+  '*.gcov',
+  '*.lst'
+];
 
+var fileNameExcludes = [
+  '*.sh',
+  '*.data',
+  '*.py',
+  '*.class',
+  '*.xcconfig',
+  'Coverage.profdata',
+  'phpunit-code-coverage.xml',
+  'coverage.serialized',
+  '*.pyc',
+  '*.cfg',
+  '*.egg',
+  '*.whl',
+  '*.html',
+  '*.js',
+  '*.cpp',
+  'coverage.jade',
+  'include.lst',
+  'inputFiles.lst',
+  'createdFiles.lst',
+  'coverage.html',
+  'scoverage.measurements.*',
+  'test_*_coverage.txt',
+  'conftest_*.c.gcov',
+  '.egg-info*'
+];
+
+var pathExcludes = [
+  'vendor',
+  'htmlcov',
+  'home/cainus',
+  'virtualenv',
+  'js/generated/coverage',
+  '.virtualenv',
+  'virtualenvs',
+  '.virtualenvs',
+  '.env',
+  '.envs',
+  'env',
+  'envs',
+  '.venv',
+  '.venvs',
+  'venv',
+  'venvs',
+  '.git',
+  '.hg',
+  '.tox',
+  '__pycache__',
+  '.egg-info*',
+  '$bower_components',
+  'node_modules'
+];
 
 var sendToCodecovV2 = function(codecov_endpoint, query, upload_body, on_success, on_failure){
   on_success = on_success || function () {};
@@ -284,11 +293,12 @@ var generate_gcov = function (args) {
 
 var get_bowerrc_patterns = function (args) {
   // Detect .bowerrc
-  var bowerrc = execSync('cd '+root+' && test -f .bowerrc && cat .bowerrc || echo ""').toString().trim(), more_patterns = '';
+  var bowerrc = execSync('cd '+root+' && test -f .bowerrc && cat .bowerrc || echo ""').toString().trim()
+  var more_patterns = null;
   if (bowerrc) {
     bowerrc = JSON.parse(bowerrc).directory;
     if (bowerrc) {
-      more_patterns = " -not -path '*/" + bowerrc.toString().replace(/\/$/, '') + "/*'";
+      more_patterns = bowerrc.toString().replace(/\/$/, '');
     }
   }
 
@@ -309,9 +319,25 @@ var get_files = function (args) {
     return [ args.options.file ];
   } else if (is_enabled(args, 'search')) {
     var more_patterns = get_bowerrc_patterns(args);
+    var excludes = pathExcludes.map(function (exclude) {
+      return '**/' + exclude + '/**';
+    }).concat(fileNameExcludes.map(function (exclude) {
+      return '**/' + exclude;
+    }));
+    if (more_patterns) {
+      excludes.push('**/' + more_patterns + '/**');
+    }
     console.log('==> Scanning for reports');
-    var out = execSync('find ' + root + ' ' + patterns + more_patterns);
-    return out.toString().trim().split('\n');
+
+    // Do it all in one @() extglob set for greater speed.
+    // This works because none of the file name patterns contain /
+    var patterns = '**/@(' + fileNamePatterns.join('|') + ')'
+    var out = glob.sync(patterns, {
+      ignore: excludes,
+      cwd: root
+    });
+
+    return out;
   } else {
     debug('disabled search');
     return [];

--- a/lib/codecov.js
+++ b/lib/codecov.js
@@ -101,6 +101,9 @@ var sendToCodecovV2 = function(codecov_endpoint, query, upload_body, on_success,
 
 
 var sendToCodecovV3 = function(codecov_endpoint, query, upload_body, on_success, on_failure){
+  on_success = on_success || function () {};
+  on_failure = on_failure || function () {};
+
   // Direct to S3
   request.post(
     {

--- a/lib/codecov.js
+++ b/lib/codecov.js
@@ -293,16 +293,14 @@ var generate_gcov = function (args) {
 
 var get_bowerrc_patterns = function (args) {
   // Detect .bowerrc
-  var bowerrc = execSync('cd '+root+' && test -f .bowerrc && cat .bowerrc || echo ""').toString().trim()
-  var more_patterns = null;
-  if (bowerrc) {
-    bowerrc = JSON.parse(bowerrc).directory;
-    if (bowerrc) {
-      more_patterns = bowerrc.toString().replace(/\/$/, '');
-    }
+  try {
+    var bowerrc = fs.readFileSync(root + '/.bowerrc', 'utf8');
+    return JSON.parse(bowerrc).directory.replace(/\/$/, '');
+  } catch (er) {
+    // any kind of error, whether because file doesn't exist,
+    // or not JSON, or directory is not a string, just ignore it.
+    return null;
   }
-
-  return more_patterns;
 };
 
 var _debug_log = [];

--- a/lib/codecov.js
+++ b/lib/codecov.js
@@ -315,6 +315,17 @@ var get_files = function (args) {
   }
 };
 
+var get_file_contents = function (file) {
+  try {
+    return fs.readFileSync(file, 'utf8');
+  } catch (er) {
+    debug('failed: ' + file.split('/').pop());
+    console.log('    X Failed to read file at ' + file);
+    return '';
+  }
+};
+
+
 var upload = function(args, on_success, on_failure) {
   // Build query
   var codecov_endpoint = get_endpoint(args);
@@ -337,15 +348,10 @@ var upload = function(args, on_success, on_failure) {
   generate_gcov(args);
 
   var files = get_files(args).filter(function (file) {
-    var contents;
-    try {
-      contents = fs.readFileSync(file, 'utf8');
-    } catch (er) {
-      debug('failed: ' + file.split('/').pop());
-      console.log('    X Failed to read file at ' + file);
+    var contents = get_file_contents(file);
+    if (!contents) {
       return false;
     }
-
     console.log('    + ' + file);
     upload += '# path=' + file + '\n' + contents + '\n<<<<<< EOF\n';
     return true;

--- a/lib/codecov.js
+++ b/lib/codecov.js
@@ -336,8 +336,6 @@ var upload = function(args, on_success, on_failure) {
 
   generate_gcov(args);
 
-  var files = [], file = null;
-
   var files = get_files(args).filter(function (file) {
     var contents;
     try {

--- a/lib/codecov.js
+++ b/lib/codecov.js
@@ -1,13 +1,7 @@
 var fs = require('fs');
 var request = require('request');
 var urlgrey = require('urlgrey');
-var execSync = require('child_process').execSync;
-if (!execSync) {
-  var exec = require('execSync').exec;
-  var execSync = function(cmd){
-    return exec(cmd).stdout;
-  };
-}
+var execSync = require('./exec-sync');
 
 var detectProvider = require('./detect');
 

--- a/lib/codecov.js
+++ b/lib/codecov.js
@@ -75,6 +75,9 @@ var patterns = "-type f \\( -name '*coverage.*' " +
 
 
 var sendToCodecovV2 = function(codecov_endpoint, query, upload_body, on_success, on_failure){
+  on_success = on_success || function () {};
+  on_failure = on_failure || function () {};
+
   // Direct to Codecov
   request.post(
     {
@@ -142,27 +145,40 @@ var sendToCodecovV3 = function(codecov_endpoint, query, upload_body, on_success,
 
 };
 
+var get_endpoint = function (args) {
+  return args.options.url ||
+    process.env.codecov_url ||
+    process.env.CODECOV_URL ||
+    'https://codecov.io';
+};
 
-var upload = function(args, on_success, on_failure){
-  // Build query
-  var codecov_endpoint = (args.options.url || process.env.codecov_url || process.env.CODECOV_URL || 'https://codecov.io');
-  var query = {};
-  var debug = [];
-
+var banner = function () {
   console.log(''+
-'  _____          _  \n' +
-' / ____|        | |  \n' +
-'| |     ___   __| | ___  ___ _____   __  \n' +
-'| |    / _ \\ / _` |/ _ \\/ __/ _ \\ \\ / /  \n' +
-'| |___| (_) | (_| |  __/ (_| (_) \\ V /  \n' +
-' \\_____\\___/ \\__,_|\\___|\\___\\___/ \\_/  \n' +
-'                                ' + version);
+    '  _____          _  \n' +
+    ' / ____|        | |  \n' +
+    '| |     ___   __| | ___  ___ _____   __  \n' +
+    '| |    / _ \\ / _` |/ _ \\/ __/ _ \\ \\ / /  \n' +
+    '| |___| (_) | (_| |  __/ (_| (_) \\ V /  \n' +
+    ' \\_____\\___/ \\__,_|\\___|\\___\\___/ \\_/  \n' +
+    '                                ' + version);
+};
 
-  if ((args.options.disable || '').split(',').indexOf('detect') === -1) {
+var is_disabled = function (args, key) {
+  return !is_enabled(args, key);
+}
+
+var is_enabled = function (args, key) {
+  return (args.options.disable || '').split(',').indexOf(key) === -1
+};
+
+var build_query = function (args) {
+  var query;
+  if (is_enabled(args, 'detect')) {
     console.log('==> Detecting CI Provider');
     query = detectProvider();
   } else {
-    debug.push('disabled detect');
+    debug('disabled detect');
+    query = {};
   }
 
   if (args.options.build) {
@@ -188,16 +204,30 @@ var upload = function(args, on_success, on_failure){
 
   query.package = 'node-' + version;
 
-  console.log("==> Configuration: ");
-  console.log("    Endpoint: " + codecov_endpoint);
-  console.log(query);
+  return query;
+};
 
-  var upload = "";
-
+var env_var_upload = function (args, query) {
   // Add specified env vars
+  var upload = "";
   var env_found = false;
   if (args.options.env || process.env.CODECOV_ENV || process.env.codecov_env) {
-    var env = (args.options.env + ',' + (process.env.CODECOV_ENV || '') + ',' + (process.env.codecov_env || '')).split(',');
+
+    var env = [];
+    if (args.options.env) {
+      env.push(args.options.env);
+    }
+
+    if (process.env.CODECOV_ENV) {
+      env.push(process.env.CODECOV_ENV);
+    }
+
+    if (process.env.codecov_env) {
+      env.push(process.env.codecov_env);
+    }
+
+    env = env.join(',').split(',');
+
     for (var i = env.length - 1; i >= 0; i--) {
       if (env[i]) {
         upload += env[i] + '=' + (process.env[env[i]] || '').toString() + '\n';
@@ -209,31 +239,55 @@ var upload = function(args, on_success, on_failure){
     }
   }
 
+  return upload;
+};
+
+var vcs_files_upload = function (args, query) {
   // List git files
   var root = args.options.root || query.root || '.';
   console.log('==> Building file structure');
-  upload += execSync('cd '+root+' && git ls-files || hg locate').toString().trim() + '\n<<<<<< network\n';
+  var list = execSync('cd '+root+' && git ls-files || hg locate');
+  return list.toString().trim() + '\n<<<<<< network\n';
+};
 
+var generate_gcov = function (args, query) {
+  var root = args.options.root || query.root || '.';
   // Make gcov reports
-  if ((args.options.disable || '').split(',').indexOf('gcov') === -1) {
+  if (is_enabled(args, 'gcov')) {
     try {
       console.log('==> Generating gcov reports (skip via --disable=gcov)');
       var gcg = args.options['gcov-glob'] || '';
       if (gcg) {
-        gcg = gcg.split(' ').map(function(p){return "-not -path '"+p+"'";}).join(' ');
+        gcg = gcg.split(' ').map(function (p) {
+          return "-not -path '"+p+"'";
+        }).join(' ');
       }
-      var gcov = "find "+(args.options['gcov-root'] || root)+" -type f -name '*.gcno' "+gcg+" -exec "+(args.options['gcov-exec'] || 'gcov')+" "+(args.options['gcov-args'] || '')+" {} +";
-      debug.push(gcov);
+
+      var gcov = "find " +
+        (args.options['gcov-root'] || root) +
+        " -type f -name '*.gcno' " +
+        gcg +
+        " -exec " +
+        (args.options['gcov-exec'] || 'gcov') +
+        " " +
+        (args.options['gcov-args'] || '') +
+        " {} +";
+
+      debug(gcov);
       console.log('    $ '+gcov);
       execSync(gcov);
     } catch (e) {
+      debug(e);
       console.log('    Failed to run gcov command.');
     }
   } else {
-    debug.push('disabled gcov');
+    debug('disabled gcov');
   }
+};
 
+var get_bowerrc_patterns = function (args, query) {
   // Detect .bowerrc
+  var root = args.options.root || query.root || '.';
   var bowerrc = execSync('cd '+root+' && test -f .bowerrc && cat .bowerrc || echo ""').toString().trim(), more_patterns = '';
   if (bowerrc) {
     bowerrc = JSON.parse(bowerrc).directory;
@@ -242,57 +296,87 @@ var upload = function(args, on_success, on_failure){
     }
   }
 
-  var files = [], file = null;
-  // Append manually entered reports
+  return more_patterns;
+};
+
+var _debug_log = [];
+var debug = function (msg) {
+  _debug_log.push(msg);
+}
+var debug_reset = function () {
+  _debug_log = [];
+}
+
+var get_files = function (args, query) {
+  var root = args.options.root || query.root || '.';
   if (args.options.file) {
-    file = args.options.file;
     console.log('==> Targeting specific file');
-    try {
-      upload += '# path=' + file + '\n' + fs.readFileSync(file, 'utf8').toString() + '\n<<<<<< EOF\n';
-      console.log('    + ' + file);
-      files.push(file);
-    } catch (e) {
-      debug.push('failed: ' + file.split('/').pop());
-      console.log('    X Failed to read file at ' + file);
-    }
-  } else if ((args.options.disable || '').split(',').indexOf('search') === -1) {
+    return [ args.options.file ];
+  } else if (is_enabled(args, 'search')) {
+    var more_patterns = get_bowerrc_patterns(args, query);
     console.log('==> Scanning for reports');
-    var _files = execSync('find ' + root + ' ' + patterns + more_patterns).toString().trim().split('\n');
-    if (_files) {
-      for (var i2 = _files.length - 1; i2 >= 0; i2--) {
-        file = _files[i2];
-        try {
-          upload += '# path=' + file + '\n' + fs.readFileSync(file, 'utf8').toString() + '\n<<<<<< EOF\n';
-          console.log('    + ' + file);
-          files.push(file);
-        } catch (e) {
-          debug.push('failed: ' + file.split('/').pop());
-          console.log('    X Failed to read file at ' + file);
-        }
-      }
-    }
+    var out = execSync('find ' + root + ' ' + patterns + more_patterns);
+    return out.toString().trim().split('\n');
   } else {
-    debug.push('disabled search');
+    debug('disabled search');
+    return [];
   }
+};
 
-  if (files) {
-    // Upload to Codecov
-    if (args.options.dump) {
-      console.log('-------- DEBUG START --------');
-      console.log(upload);
-      console.log('-------- DEBUG END --------');
+var upload = function(args, on_success, on_failure) {
+  // Build query
+  var codecov_endpoint = get_endpoint(args);
+  debug_reset();
 
-    } else {
-      console.log('==> Uploading reports');
-      sendToCodecovV3(codecov_endpoint, query, upload, on_success || function(){}, on_failure || function(){});
+  banner();
+
+  var query = build_query(args);
+
+  var root = args.options.root || query.root || '.';
+  console.log("==> Configuration: ");
+  console.log("    Endpoint: " + codecov_endpoint);
+  console.log(query);
+
+  var upload = "";
+
+  upload += env_var_upload(args, query);
+  upload += vcs_files_upload(args, query);
+
+  generate_gcov(args, query);
+
+  var files = [], file = null;
+
+  var files = get_files(args, query).filter(function (file) {
+    var contents;
+    try {
+      contents = fs.readFileSync(file, 'utf8');
+    } catch (er) {
+      debug('failed: ' + file.split('/').pop());
+      console.log('    X Failed to read file at ' + file);
+      return false;
     }
+
+    console.log('    + ' + file);
+    upload += '# path=' + file + '\n' + contents + '\n<<<<<< EOF\n';
+    return true;
+  });
+
+  // Upload to Codecov
+  if (args.options.dump) {
+    console.log('-------- DEBUG START --------');
+    console.log(upload);
+    console.log('-------- DEBUG END --------');
+
+  } else {
+    console.log('==> Uploading reports');
+    sendToCodecovV3(codecov_endpoint, query, upload, on_success, on_failure);
   }
 
   return {
     body: upload,
     files: files,
     query: query,
-    debug: debug,
+    debug: _debug_log,
     url: codecov_endpoint
   };
 

--- a/lib/codecov.js
+++ b/lib/codecov.js
@@ -262,25 +262,19 @@ var generate_gcov = function (args) {
   if (is_enabled(args, 'gcov')) {
     try {
       console.log('==> Generating gcov reports (skip via --disable=gcov)');
+
       var gcg = args.options['gcov-glob'] || '';
-      if (gcg) {
-        gcg = gcg.split(' ').map(function (p) {
-          return "-not -path '"+p+"'";
-        }).join(' ');
-      }
+      gcg = gcg.split(' ');
+      var gcovRoot = args.options['gcov-root'] || root;
+      var gcovFiles = glob.sync(gcovRoot + '/**/*.gcno', {
+        ignore: gcg
+      });
 
-      var gcov = "find " +
-        (args.options['gcov-root'] || root) +
-        " -type f -name '*.gcno' " +
-        gcg +
-        " -exec " +
-        (args.options['gcov-exec'] || 'gcov') +
-        " " +
-        (args.options['gcov-args'] || '') +
-        " {} +";
-
-      debug(gcov);
+      var gcovExec = args.options['gcov-exec'] || 'gcov';
+      var gcovArgs = args.options['gcov-args'] || '';
+      var gcov = gcovExec + ' ' + gcovArgs + ' ' + gcovFiles.join(' ');
       console.log('    $ '+gcov);
+      debug(gcov);
       execSync(gcov);
     } catch (e) {
       debug(e);

--- a/lib/codecov.js
+++ b/lib/codecov.js
@@ -5,6 +5,8 @@ var execSync = require('./exec-sync');
 
 var detectProvider = require('./detect');
 
+var root;
+
 var version = "v1.0.1";
 
 var patterns = "-type f \\( -name '*coverage.*' " +
@@ -201,7 +203,7 @@ var build_query = function (args) {
   return query;
 };
 
-var env_var_upload = function (args, query) {
+var env_var_upload = function (args) {
   // Add specified env vars
   var upload = "";
   var env_found = false;
@@ -236,16 +238,14 @@ var env_var_upload = function (args, query) {
   return upload;
 };
 
-var vcs_files_upload = function (args, query) {
+var vcs_files_upload = function (args) {
   // List git files
-  var root = args.options.root || query.root || '.';
   console.log('==> Building file structure');
   var list = execSync('cd '+root+' && git ls-files || hg locate');
   return list.toString().trim() + '\n<<<<<< network\n';
 };
 
-var generate_gcov = function (args, query) {
-  var root = args.options.root || query.root || '.';
+var generate_gcov = function (args) {
   // Make gcov reports
   if (is_enabled(args, 'gcov')) {
     try {
@@ -279,9 +279,8 @@ var generate_gcov = function (args, query) {
   }
 };
 
-var get_bowerrc_patterns = function (args, query) {
+var get_bowerrc_patterns = function (args) {
   // Detect .bowerrc
-  var root = args.options.root || query.root || '.';
   var bowerrc = execSync('cd '+root+' && test -f .bowerrc && cat .bowerrc || echo ""').toString().trim(), more_patterns = '';
   if (bowerrc) {
     bowerrc = JSON.parse(bowerrc).directory;
@@ -301,13 +300,12 @@ var debug_reset = function () {
   _debug_log = [];
 }
 
-var get_files = function (args, query) {
-  var root = args.options.root || query.root || '.';
+var get_files = function (args) {
   if (args.options.file) {
     console.log('==> Targeting specific file');
     return [ args.options.file ];
   } else if (is_enabled(args, 'search')) {
-    var more_patterns = get_bowerrc_patterns(args, query);
+    var more_patterns = get_bowerrc_patterns(args);
     console.log('==> Scanning for reports');
     var out = execSync('find ' + root + ' ' + patterns + more_patterns);
     return out.toString().trim().split('\n');
@@ -326,21 +324,21 @@ var upload = function(args, on_success, on_failure) {
 
   var query = build_query(args);
 
-  var root = args.options.root || query.root || '.';
+  root = args.options.root || query.root || '.';
   console.log("==> Configuration: ");
   console.log("    Endpoint: " + codecov_endpoint);
   console.log(query);
 
   var upload = "";
 
-  upload += env_var_upload(args, query);
-  upload += vcs_files_upload(args, query);
+  upload += env_var_upload(args);
+  upload += vcs_files_upload(args);
 
-  generate_gcov(args, query);
+  generate_gcov(args);
 
   var files = [], file = null;
 
-  var files = get_files(args, query).filter(function (file) {
+  var files = get_files(args).filter(function (file) {
     var contents;
     try {
       contents = fs.readFileSync(file, 'utf8');

--- a/lib/exec-sync.js
+++ b/lib/exec-sync.js
@@ -1,0 +1,9 @@
+var execSync = require('child_process').execSync;
+if (!execSync) {
+  var exec = require('execSync').exec;
+  var execSync = function(cmd){
+    return exec(cmd).stdout;
+  };
+}
+
+module.exports = execSync;

--- a/lib/services/drone.js
+++ b/lib/services/drone.js
@@ -1,10 +1,4 @@
-var execSync = require('child_process').execSync;
-if (!execSync) {
-  var exec = require('execSync').exec;
-  var execSync = function(cmd){
-    return exec(cmd).stdout;
-  };
-}
+var execSync = require('../exec-sync');
 
 module.exports = {
 

--- a/lib/services/localGit.js
+++ b/lib/services/localGit.js
@@ -1,10 +1,4 @@
-var execSync = require('child_process').execSync;
-if (!execSync) {
-  var exec = require('execSync').exec;
-  var execSync = function(cmd){
-    return exec(cmd).stdout;
-  };
-}
+var execSync = require('../exec-sync');
 
 module.exports = {
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Uploading report to Codecov: https://codecov.io",
   "main": "index.js",
   "scripts": {
+    "pretest": "rimraf ./coverage/",
     "test": "./node_modules/.bin/istanbul cover ./node_modules/mocha/bin/_mocha -- -R spec"
   },
   "repository": {
@@ -35,6 +36,7 @@
     "expect.js": "0.3.1",
     "istanbul": "0.3.2",
     "jshint": "2.5.5",
-    "mocha": "2.2.1"
+    "mocha": "2.2.1",
+    "rimraf": "^2.5.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,10 +27,11 @@
   },
   "homepage": "https://github.com/codecov/codecov-node",
   "dependencies": {
-    "request": ">=2.42.0",
-    "urlgrey": ">=0.4.0",
     "argv": ">=0.0.2",
-    "execSync": "1.0.2"
+    "execSync": "1.0.2",
+    "glob": "^7.0.3",
+    "request": ">=2.42.0",
+    "urlgrey": ">=0.4.0"
   },
   "devDependencies": {
     "expect.js": "0.3.1",

--- a/test/detect.js
+++ b/test/detect.js
@@ -1,12 +1,6 @@
 
 var detect = require("../lib/detect");
-var execSync = require('child_process').execSync;
-if (!execSync) {
-  var exec = require('execSync').exec;
-  var execSync = function(cmd){
-    return exec(cmd).stdout;
-  };
-}
+var execSync = require('../lib/exec-sync');
 
 describe("Codecov", function(){
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,7 @@
 var fs = require('fs');
 var codecov = require("../lib/codecov");
 var execSync = require('child_process').execSync;
+var rimraf = require('rimraf');
 if (!execSync) {
   var exec = require('execSync').exec;
   var execSync = function(cmd){
@@ -118,13 +119,22 @@ describe("Codecov", function(){
   });
 
   it("can have custom args for gcov", function(){
+    rimraf.sync(__dirname + '/gcov-test');
+
+    fs.mkdirSync(__dirname + '/gcov-test');
+    fs.mkdirSync(__dirname + '/gcov-test/ignore');
+    fs.writeFileSync(__dirname + '/gcov-test/test.gcno', 'testing\n');
+    fs.writeFileSync(__dirname + '/gcov-test/ignore/test.gcno', 'testing\n');
+
     var res = codecov.upload({options: {dump: true,
-                                        'gcov-root': 'folder/path',
-                                        'gcov-glob': 'ignore/this/folder',
+                                        'gcov-root': 'test/gcov-test',
+                                        'gcov-glob': 'test/gcov-test/ignore/**',
                                         'gcov-exec': 'llvm-gcov',
                                         'gcov-args': '-o'}});
-    expect(res.debug).to.contain('find folder/path -type f -name \'*.gcno\' -not -path \'ignore/this/folder\' -exec llvm-gcov -o {} +');
-  });
 
+    rimraf.sync(__dirname + '/gcov-test');
+
+    expect(res.debug).to.contain('llvm-gcov -o test/gcov-test/test.gcno');
+  });
 
 });

--- a/test/services/drone.js
+++ b/test/services/drone.js
@@ -1,11 +1,5 @@
 var drone = require("../../lib/services/drone");
-var execSync = require('child_process').execSync;
-if (!execSync) {
-  var exec = require('execSync').exec;
-  var execSync = function(cmd){
-    return exec(cmd).stdout;
-  };
-}
+var execSync = require('../../lib/exec-sync');
 
 describe("Drone.io CI Provider", function(){
 

--- a/test/services/localGit.js
+++ b/test/services/localGit.js
@@ -1,11 +1,5 @@
 var local = require("../../lib/services/localGit");
-var execSync = require('child_process').execSync;
-if (!execSync) {
-  var exec = require('execSync').exec;
-  var execSync = function(cmd){
-    return exec(cmd).stdout;
-  };
-}
+var execSync = require('../../lib/exec-sync');
 
 describe("Local git/mercurial CI Provider", function(){
 

--- a/test/upload.js
+++ b/test/upload.js
@@ -1,13 +1,6 @@
 var fs = require('fs');
 var codecov = require("../lib/codecov");
-var execSync = require('child_process').execSync;
-if (!execSync) {
-  var exec = require('execSync').exec;
-  var execSync = function(cmd){
-    return exec(cmd).stdout;
-  };
-}
-
+var execSync = require('../lib/exec-sync');
 
 describe("Codecov", function(){
   it("can get upload to v2", function(done){

--- a/test/upload.js
+++ b/test/upload.js
@@ -19,7 +19,7 @@ describe("Codecov", function(){
                             },
                             'testing node-'+codecov.version,
                             function(body){
-                              expect(body).to.contain('http://codecov.io/github/codecov/ci-repo?ref=c739768fcac68144a3a6d82305b9c4106934d31a');
+                              expect(body).to.match(/http:\/\/codecov\.io\/github\/codecov\/ci-repo(\?ref=|\/commit\/)c739768fcac68144a3a6d82305b9c4106934d31a/);
                               done();
                             },
                             function(err){
@@ -36,7 +36,7 @@ describe("Codecov", function(){
                             },
                             'testing node-'+codecov.version,
                             function(body){
-                              expect(body).to.contain('http://codecov.io/github/codecov/ci-repo?ref=c739768fcac68144a3a6d82305b9c4106934d31a');
+                              expect(body).to.match(/http:\/\/codecov\.io\/github\/codecov\/ci-repo(\?ref=|\/commit\/)c739768fcac68144a3a6d82305b9c4106934d31a/);
                               done();
                             },
                             function(err){


### PR DESCRIPTION
This is the first step in moving away from using execSync, and eventually making this module work on Windows.

The major steps in the `upload` function have been factored out into separate functions.  What's remaining is to make all `exec` invocations asynchronous (so that execSync isn't needed), remove unix-specific command line utils, and remove sh-specific piping (`&&`, `||`, etc.)

Still todo after this:
- [ ] Swap to async API surface. (Ie, `upload` takes a callback, each of the sub-routines are async and also take callbacks.  Promises would also be fine, any preferences?)
- [x] Replace `find` invocations with `glob` to search for coverage output files (can be sync)
- [x] Use `glob` to find `*.gcno` files for passing to `gcov-exec`
- [ ] Make service detection async
- [x] Use `fs` to read bowerrc, rather than `cat`.  (Also: the `cd` there is problematic.  `root` can contain spaces!)
- [ ] Separate git and hg into separate services, call appropriately based on presence of `.git` or `.hg` directory.

I've tried to match the existing style as closely as possible.  There should be no behavior change with this patch; it's strictly to make the subsequent changes more straightforward.
