### PR TITLE
Detect config file in the root folder

### DIFF
--- a/lib/codecov.js
+++ b/lib/codecov.js
@@ -1,4 +1,5 @@
 var fs = require('fs');
+var path = require('path');
 var request = require('request');
 var urlgrey = require('urlgrey');
 var execSync = require('child_process').execSync;
@@ -157,6 +158,10 @@ var upload = function(args, on_success, on_failure){
 '| |___| (_) | (_| |  __/ (_| (_) \\ V /  \n' +
 ' \\_____\\___/ \\__,_|\\___|\\___\\___/ \\_/  \n' +
 '                                ' + version);
+
+  query.yaml = ['codecov.yml', '.codecov.yml'].reduce(function (result, file) {
+    return result || (fs.existsSync(path.resolve(process.cwd(), file)) ? file : undefined)
+  }, undefined)
 
   if ((args.options.disable || '').split(',').indexOf('detect') === -1) {
     console.log('==> Detecting CI Provider');


### PR DESCRIPTION
:wave: 

I wanted to add support for hidden `codecov.yml`, regarding this issue https://github.com/codecov/support/issues/189.

Is this the correct query parameter to use? It doesn't seems to work with this PR https://github.com/request/request/pull/2204. Also changing the name from `codecov.yml` to `.codecov.yml` results in immediate comment on push to GitHub, so it seems that's hook related rather than uploader related, which happens much later in time.