### PR TITLE
Remove all use of the package execSync

### DIFF
--- a/lib/codecov.js
+++ b/lib/codecov.js
@@ -3,12 +3,6 @@ var path = require('path');
 var request = require('request');
 var urlgrey = require('urlgrey');
 var execSync = require('child_process').execSync;
-if (!execSync) {
-  var exec = require('execSync').exec;
-  var execSync = function(cmd){
-    return exec(cmd).stdout;
-  };
-}
 
 var detectProvider = require('./detect');
 

--- a/lib/services/drone.js
+++ b/lib/services/drone.js
@@ -1,10 +1,4 @@
 var execSync = require('child_process').execSync;
-if (!execSync) {
-  var exec = require('execSync').exec;
-  var execSync = function(cmd){
-    return exec(cmd).stdout;
-  };
-}
 
 module.exports = {
 

--- a/lib/services/localGit.js
+++ b/lib/services/localGit.js
@@ -1,10 +1,4 @@
 var execSync = require('child_process').execSync;
-if (!execSync) {
-  var exec = require('execSync').exec;
-  var execSync = function(cmd){
-    return exec(cmd).stdout;
-  };
-}
 
 module.exports = {
 

--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
   "dependencies": {
     "request": ">=2.42.0",
     "urlgrey": ">=0.4.0",
-    "argv": ">=0.0.2",
-    "execSync": "1.0.2"
+    "argv": ">=0.0.2"
   },
   "devDependencies": {
     "expect.js": "0.3.1",

--- a/test/detect.js
+++ b/test/detect.js
@@ -1,12 +1,6 @@
 
 var detect = require("../lib/detect");
 var execSync = require('child_process').execSync;
-if (!execSync) {
-  var exec = require('execSync').exec;
-  var execSync = function(cmd){
-    return exec(cmd).stdout;
-  };
-}
 
 describe("Codecov", function(){
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,13 +1,6 @@
 var fs = require('fs');
 var codecov = require("../lib/codecov");
 var execSync = require('child_process').execSync;
-if (!execSync) {
-  var exec = require('execSync').exec;
-  var execSync = function(cmd){
-    return exec(cmd).stdout;
-  };
-}
-
 
 describe("Codecov", function(){
   beforeEach(function(){

--- a/test/services/drone.js
+++ b/test/services/drone.js
@@ -1,11 +1,5 @@
 var drone = require("../../lib/services/drone");
 var execSync = require('child_process').execSync;
-if (!execSync) {
-  var exec = require('execSync').exec;
-  var execSync = function(cmd){
-    return exec(cmd).stdout;
-  };
-}
 
 describe("Drone.io CI Provider", function(){
 

--- a/test/services/localGit.js
+++ b/test/services/localGit.js
@@ -1,11 +1,5 @@
 var local = require("../../lib/services/localGit");
 var execSync = require('child_process').execSync;
-if (!execSync) {
-  var exec = require('execSync').exec;
-  var execSync = function(cmd){
-    return exec(cmd).stdout;
-  };
-}
 
 describe("Local git/mercurial CI Provider", function(){
 

--- a/test/upload.js
+++ b/test/upload.js
@@ -1,13 +1,6 @@
 var fs = require('fs');
 var codecov = require("../lib/codecov");
 var execSync = require('child_process').execSync;
-if (!execSync) {
-  var exec = require('execSync').exec;
-  var execSync = function(cmd){
-    return exec(cmd).stdout;
-  };
-}
-
 
 describe("Codecov", function(){
   it("can get upload to v2", function(done){


### PR DESCRIPTION
Alternative to #14 that only removes use of the `execSync` module, doesn't change the current code setup. It does make any new release of this package only work on node `>=0.12.x`.
