### PR TITLE
Support CircleCI 2.0

### DIFF
--- a/lib/services/circle.js
+++ b/lib/services/circle.js
@@ -13,8 +13,23 @@ module.exports = {
       commit : process.env.CIRCLE_SHA1,
       branch : process.env.CIRCLE_BRANCH,
       pr: process.env.CIRCLE_PR_NUMBER,
-      slug : process.env.CIRCLE_PROJECT_USERNAME + '/' + process.env.CIRCLE_PROJECT_REPONAME,
+      slug : detectRepoSlug(),
     };
+    function detectRepoSlug(){
+      if (process.env.CIRCLE_PROJECT_REPONAME) {
+        // CircleCI 1.0
+        //   CIRCLE_PROJECT_REPONAME=codecov
+        //   CIRCLE_PROJECT_USERNAME=codecov-node
+        //   CIRCLE_REPOSITORY_URL=https://github.com/codecov/codecov-node (note: GitHub Web URL)
+        return process.env.CIRCLE_PROJECT_USERNAME + '/' + process.env.CIRCLE_PROJECT_REPONAME;
+      }
+      if (process.env.CIRCLE_REPOSITORY_URL) {
+        // CircleCI 2.0
+        //   CIRCLE_REPOSITORY_URL=git@github.com:codecov/codecov-node.git (note: Git/SSH URL)
+        return process.env.CIRCLE_REPOSITORY_URL.replace(/^.*:/, '').replace(/\.git$/, '');
+      }
+      throw new Error('Cannot detect repository slug.');
+    }
   }
 
 };

--- a/test/services/circle.js
+++ b/test/services/circle.js
@@ -51,4 +51,14 @@ describe("Circle CI Provider", function(){
     });
   });
 
+  it ("throws if repo slug cannot be detected", function(){
+    delete process.env.CIRCLE_PR_NUMBER;
+    delete process.env.CIRCLE_PROJECT_USERNAME;
+    delete process.env.CIRCLE_PROJECT_REPONAME;
+    delete process.env.CIRCLE_REPOSITORY_URL;
+    expect(function(){
+      circle.configuration();
+    }).to.throw(Error);
+  });
+
 });

--- a/test/services/circle.js
+++ b/test/services/circle.js
@@ -7,7 +7,7 @@ describe("Circle CI Provider", function(){
     expect(circle.detect()).to.be(true);
   });
 
-  it ("can get circle env info get_commit_status", function(){
+  it ("can get circle env info (CircleCI 1.0)", function(){
     process.env.CIRCLECI = 'true';
     process.env.CIRCLE_BUILD_NUM = '1234';
     process.env.CIRCLE_SHA1 = '5678';
@@ -23,6 +23,30 @@ describe("Circle CI Provider", function(){
       job : '1234.1',
       branch : 'master',
       pr : 'blah',
+      slug : 'owner/repo'
+    });
+  });
+
+  it ("can get circle env info (CircleCI 2.0)", function(){
+    process.env.CIRCLECI = 'true';
+    process.env.CIRCLE_BRANCH = 'master';
+    process.env.CIRCLE_BUILD_NUM = '1234';
+    process.env.CIRCLE_SHA1 = 'abcd';
+    process.env.CIRCLE_NODE_INDEX = '1';
+    process.env.CIRCLE_BUILD_URL = 'https://circleci.com/gh/owner/repo/1234';
+    process.env.CIRCLE_COMPARE_URL = 'https://github.com/owner/repo/2408ca9...3c36cfa';
+    process.env.CIRCLE_NODE_INDEX = '1';
+    process.env.CIRCLE_REPOSITORY_URL = 'git@github.com:owner/repo.git';
+    delete process.env.CIRCLE_PR_NUMBER;
+    delete process.env.CIRCLE_PROJECT_USERNAME;
+    delete process.env.CIRCLE_PROJECT_REPONAME;
+    expect(circle.configuration()).to.eql({
+      service : 'circleci',
+      commit : 'abcd',
+      build : '1234.1',
+      job : '1234.1',
+      branch : 'master',
+      pr : undefined,
       slug : 'owner/repo'
     });
   });

--- a/test/upload.js
+++ b/test/upload.js
@@ -21,7 +21,7 @@ describe("Codecov", function(){
                             },
                             'testing node-'+codecov.version,
                             function(body){
-                              expect(body).to.contain('http://codecov.io/github/codecov/ci-repo/commit/c739768fcac68144a3a6d82305b9c4106934d31a');
+                              expect(body).to.contain('https://codecov.io/github/codecov/ci-repo/commit/c739768fcac68144a3a6d82305b9c4106934d31a');
                               done();
                             },
                             function(errCode, errMsg){
@@ -44,7 +44,7 @@ describe("Codecov", function(){
                             },
                             'testing node-'+codecov.version,
                             function(body){
-                              expect(body).to.contain('http://codecov.io/github/codecov/ci-repo/commit/c739768fcac68144a3a6d82305b9c4106934d31a');
+                              expect(body).to.contain('https://codecov.io/github/codecov/ci-repo/commit/c739768fcac68144a3a6d82305b9c4106934d31a');
                               done();
                             },
                             function(errCode, errMsg){
@@ -66,7 +66,7 @@ describe("Codecov", function(){
                             },
                             'testing node-'+codecov.version,
                             function(body){
-                              expect(body).to.contain('http://codecov.io/github/codecov/ci-repo/commit/c739768fcac68144a3a6d82305b9c4106934d31a');
+                              expect(body).to.contain('https://codecov.io/github/codecov/ci-repo/commit/c739768fcac68144a3a6d82305b9c4106934d31a');
                               done();
                             },
                             function(errCode, errMsg){


### PR DESCRIPTION
[CircleCI 2.0](https://circleci.com/blog/say-hello-to-circleci-2-0/), currently in closed beta, supports Docker out-of-the-box. It brings [a lot of nice improvements](https://discuss.circleci.com/t/circleci-2-0-overview/8086).

However, [there are changes in environment variables](https://discuss.circleci.com/t/circleci-environment-variables-1-0-vs-2-0/9584). The variables `CIRCLE_PROJECT_USERNAME` and `CIRCLE_PROJECT_REPONAME` has been removed.

This PR makes `codecov-node` support running inside CircleCI 2.0.

## Output comparison

### Before (bash version)

```
HTTP 400
slug must match pattern ^[\w\-\.]{1,255}\/[\w\-\.]{1,255}$
```

Coverage data is not uploaded.

### Before (node version)

```
==> Detecting CI Provider
    Circle CI Detected
==> Configuration: 
    Endpoint: https://codecov.io
{ service: 'circleci',
  build: '70.0',
  job: '70.0',
  commit: '7d0aaca1f17ee2c56f4448d7d3c1e35fc838ddab',
  branch: 'my-record',
  pr: undefined,
  slug: 'undefined/undefined',
  package: 'node-v1.0.1' }
...
==> Uploading reports
    HTTP 400
Unable to locate build via CircleCI API. Please upload with the Codecov repository upload token to resolve issue.
```

Slug is `undefined/undefined`. Coverage data is not uploaded.

### After (node version)

```
==> Detecting CI Provider
    Circle CI Detected
==> Configuration: 
    Endpoint: https://codecov.io
{ service: 'circleci',
  build: '71.0',
  job: '71.0',
  commit: 'e45d8b7e512e3110501f36c7814eae5c5cb97f26',
  branch: 'my-record',
  pr: undefined,
  slug: 'bemusic/scoreboard',
  package: 'node-v1.0.1' }
...
==> Uploading reports
    Success!
    View report at: https://codecov.io/github/bemusic/scoreboard/commit/e45d8b7e512e3110501f36c7814eae5c5cb97f26
```

Coverage data uploaded successfully, despite `pr` being `undefined`.