### PR TITLE
Take version from package.json

### DIFF
--- a/lib/codecov.js
+++ b/lib/codecov.js
@@ -6,7 +6,7 @@ var execSync = require('child_process').execSync;
 
 var detectProvider = require('./detect');
 
-var version = require('../package.json').version;
+var version = 'v' + require('../package.json').version;
 
 var patterns = "-type f \\( -name '*coverage.*' " +
                "-or -name 'nosetests.xml' " +

--- a/lib/codecov.js
+++ b/lib/codecov.js
@@ -6,7 +6,7 @@ var execSync = require('child_process').execSync;
 
 var detectProvider = require('./detect');
 
-var version = "v1.0.1";
+var version = require('../package.json').version;
 
 var patterns = "-type f \\( -name '*coverage.*' " +
                "-or -name 'nosetests.xml' " +

--- a/test/index.js
+++ b/test/index.js
@@ -128,7 +128,7 @@ describe("Codecov", function(){
 
   it('should have the correct version number', function() {
     var version = require('../package.json').version
-    expect(codecov.version).to.eql(version)
+    expect(codecov.version).to.eql('v' + version)
   })
 
 

--- a/test/index.js
+++ b/test/index.js
@@ -126,5 +126,10 @@ describe("Codecov", function(){
     expect(res.debug).to.contain('find folder/path -type f -name \'*.gcno\' -not -path \'ignore/this/folder\' -exec llvm-gcov -o {} +');
   });
 
+  it('should have the correct version number', function() {
+    var version = require('../package.json').version
+    expect(codecov.version).to.eql(version)
+  })
+
 
 });


### PR DESCRIPTION
Instead of a hard coded version number, use the version from the package.json file
Closes #51 