### PR TITLE
Coverage upload on Windows - fixes #61

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,30 @@
+environment:
+  matrix:
+  - nodejs_version: "7"
+  - nodejs_version: "6"
+  - nodejs_version: "5"
+  - nodejs_version: "4"
+  - nodejs_version: "0.12"
+  - nodejs_version: "1.0"
+
+max_jobs: 4
+
+clone_depth: 50
+
+init:
+  - git config --global core.autocrlf true
+
+install:
+  - ps: Install-Product node $env:nodejs_version
+  - npm install
+
+test_script:
+  - cmd: SET PATH=C:\MinGW\bin;%PATH%
+  - npm run test
+
+after_test:
+  - .\bin\codecov -f coverage\coverage.json
+
+build: off
+
+deploy: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ test_script:
   - npm run test
 
 after_test:
-  - .\bin\codecov -f coverage\coverage.json
+  - node .\bin\codecov -f coverage\coverage.json
 
 build: off
 

--- a/lib/codecov.js
+++ b/lib/codecov.js
@@ -318,9 +318,9 @@ var upload = function(args, on_success, on_failure){
   // Detect .bowerrc
   var bowerrc;
   if(!isWindows) {
-    bowerrc = execSync('cd '+root+' && test -f .bowerrc && cat .bowerrc || echo ""').toString().trim(), more_patterns = '';
+    bowerrc = execSync('cd '+root+' && test -f .bowerrc && cat .bowerrc || echo ""').toString().trim();
   } else {
-    bowerrc = execSync('cd '+root+' && if exist .bowerrc type .bowerrc').toString().trim(), more_patterns = '';
+    bowerrc = execSync('cd '+root+' && if exist .bowerrc type .bowerrc').toString().trim();
   }
   if (bowerrc) {
     bowerrc = JSON.parse(bowerrc).directory;

--- a/lib/codecov.js
+++ b/lib/codecov.js
@@ -8,7 +8,13 @@ var detectProvider = require('./detect');
 
 var version = 'v' + require('../package.json').version;
 
-var patterns = "-type f \\( -name '*coverage.*' " +
+var patterns, more_patterns = '';
+
+var isWindows = process.platform.match(/win32/) || process.platform.match(/win64/)
+
+if(!isWindows) {
+  patterns
+             = "-type f \\( -name '*coverage.*' " +
                "-or -name 'nosetests.xml' " +
                "-or -name 'jacoco*.xml' " +
                "-or -name 'clover.xml' " +
@@ -66,7 +72,68 @@ var patterns = "-type f \\( -name '*coverage.*' " +
                "-not -path '*/$bower_components/*' " +
                "-not -path '*/node_modules/*' " +
                "-not -path '*/conftest_*.c.gcov'";
-
+}
+else {
+  patterns
+             = '/a-d /b /s *coverage.* ' +
+               '/s nosetests.xml ' +
+               '/s jacoco*.xml ' +
+               '/s clover.xml ' +
+               '/s report.xml ' +
+               '/s cobertura.xml ' +
+               '/s luacov.report.out ' +
+               '/s lcov.info ' +
+               '/s *.lcov ' +
+               '/s gcov.info ' +
+               '/s *.gcov ' +
+               '/s *.lst' +
+               '| findstr /i /v \\.sh$ ' +
+               '| findstr /i /v \\.data$ ' +
+               '| findstr /i /v \\.py$ ' +
+               '| findstr /i /v \\.class$ ' +
+               '| findstr /i /v \\.xcconfig$ ' +
+               '| findstr /i /v Coverage\\.profdata$ ' +
+               '| findstr /i /v phpunit-code-coverage\\.xml$ ' +
+               '| findstr /i /v coverage\\.serialized$ ' +
+               '| findstr /i /v \\.pyc$ ' +
+               '| findstr /i /v \\.cfg$ ' +
+               '| findstr /i /v \\.egg$ ' +
+               '| findstr /i /v \\.whl$ ' +
+               '| findstr /i /v \\.html$ ' +
+               '| findstr /i /v \\.js$ ' +
+               '| findstr /i /v \\.cpp$ ' +
+               '| findstr /i /v coverage\\.jade$ ' +
+               '| findstr /i /v include\\.lst$ ' +
+               '| findstr /i /v inputFiles\\.lst$ ' +
+               '| findstr /i /v createdFiles\\.lst$ ' +
+               '| findstr /i /v coverage\\.html$ ' +
+               '| findstr /i /v scoverage\\.measurements\\..* ' +
+               '| findstr /i /v test_.*_coverage\\.txt ' +
+               '| findstr /i /v \\vendor\\ ' +
+               '| findstr /i /v \\htmlcov\\ ' +
+               '| findstr /i /v \\home\\cainus\\ ' +
+               '| findstr /i /v \\js\\generated\\coverage\\ ' +
+               '| findstr /i /v \\virtualenv\\ ' +
+               '| findstr /i /v \\virtualenvs\\ ' +
+               '| findstr /i /v \\\\.virtualenv\\ ' +
+               '| findstr /i /v \\\\.virtualenvs\\ ' +
+               '| findstr /i /v \\\\.env\\ ' +
+               '| findstr /i /v \\\\.envs\\ ' +
+               '| findstr /i /v \\env\\ ' +
+               '| findstr /i /v \\envs\\ ' +
+               '| findstr /i /v \\\\.venv\\ ' +
+               '| findstr /i /v \\\\.venvs\\ ' +
+               '| findstr /i /v \\venv\\ ' +
+               '| findstr /i /v \\venvs\\ ' +
+               '| findstr /i /v \\\\.git\\ ' +
+               '| findstr /i /v \\\\.hg\\ ' +
+               '| findstr /i /v \\\\.tox\\ ' +
+               '| findstr /i /v \\__pycache__\\ ' +
+               '| findstr /i /v \\\\.egg-info* ' +
+               '| findstr /i /v \\\\$bower_components\\ ' +
+               '| findstr /i /v \\node_modules\\ ' +
+               '| findstr /i /v \\conftest_.*\\.c\\.gcov ';
+}
 
 
 var sendToCodecovV2 = function(codecov_endpoint, query, upload_body, on_success, on_failure){
@@ -214,7 +281,7 @@ var upload = function(args, on_success, on_failure){
   }
 
   // List git files
-  var root = args.options.root || query.root || '.';
+  var root = path.resolve(args.options.root || query.root || '.');
   console.log('==> Building file structure');
   upload += execSync('cd '+root+' && git ls-files || hg locate').toString().trim() + '\n<<<<<< network\n';
 
@@ -224,9 +291,20 @@ var upload = function(args, on_success, on_failure){
       console.log('==> Generating gcov reports (skip via --disable=gcov)');
       var gcg = args.options['gcov-glob'] || '';
       if (gcg) {
-        gcg = gcg.split(' ').map(function(p){return "-not -path '"+p+"'";}).join(' ');
+        if(!isWindows) {
+          gcg = gcg.split(' ').map(function(p){return "-not -path '"+p+"'";}).join(' ');
+        } else {
+          gcg = gcg.split(' ').map(function(p){return "^| findstr /i /v "+p;}).join(' ');
+        }
       }
-      var gcov = "find "+(args.options['gcov-root'] || root)+" -type f -name '*.gcno' "+gcg+" -exec "+(args.options['gcov-exec'] || 'gcov')+" "+(args.options['gcov-args'] || '')+" {} +";
+      var gcov;
+      if(!isWindows) {
+        gcov = "find "+(args.options['gcov-root'] || root)+" -type f -name '*.gcno' "+gcg+" -exec "+(args.options['gcov-exec'] || 'gcov')+" "+(args.options['gcov-args'] || '')+" {} +";
+      } else {
+        // @TODO support for root
+        // not straight forward due to nature of windows command dir
+        gcov = "for /f \"delims=\" %g in ('dir /a-d /b /s *.gcno "+gcg+"') do "+(args.options['gcov-exec'] || 'gcov')+" "+(args.options['gcov-args'] || '')+" %g";
+      }
       debug.push(gcov);
       console.log('    $ '+gcov);
       execSync(gcov);
@@ -238,11 +316,20 @@ var upload = function(args, on_success, on_failure){
   }
 
   // Detect .bowerrc
-  var bowerrc = execSync('cd '+root+' && test -f .bowerrc && cat .bowerrc || echo ""').toString().trim(), more_patterns = '';
+  var bowerrc;
+  if(!isWindows) {
+    bowerrc = execSync('cd '+root+' && test -f .bowerrc && cat .bowerrc || echo ""').toString().trim(), more_patterns = '';
+  } else {
+    bowerrc = execSync('cd '+root+' && if exist .bowerrc type .bowerrc').toString().trim(), more_patterns = '';
+  }
   if (bowerrc) {
     bowerrc = JSON.parse(bowerrc).directory;
     if (bowerrc) {
-      more_patterns = " -not -path '*/" + bowerrc.toString().replace(/\/$/, '') + "/*'";
+      if(!isWindows) {
+        more_patterns = " -not -path '*/" + bowerrc.toString().replace(/\/$/, '') + "/*'";
+      } else {
+        more_patterns = '| findstr /i /v \\' + bowerrc.toString().replace(/\/$/, '') + '\\';
+      }
     }
   }
 
@@ -261,7 +348,14 @@ var upload = function(args, on_success, on_failure){
     }
   } else if ((args.options.disable || '').split(',').indexOf('search') === -1) {
     console.log('==> Scanning for reports');
-    var _files = execSync('find ' + root + ' ' + patterns + more_patterns).toString().trim().split('\n');
+    var _files
+    if(!isWindows) {
+      _files = execSync('find ' + root + ' ' + patterns + more_patterns).toString().trim().split('\n');
+    } else {
+      // @TODO support for a root directory
+      // It's not straightforward due to the nature of the dir command
+      _files = execSync('dir ' + patterns + more_patterns).toString().trim().split('\r\n');
+    }
     if (_files) {
       for (var i2 = _files.length - 1; i2 >= 0; i2--) {
         file = _files[i2];


### PR DESCRIPTION
Uploading coverage data from Windows machines works with these changes. The changes have been tested using Appveyor.

### Modifications

- Ported the coverage upload code to work on Windows
   - Paths and files exclusion and inclusion filters
   - Exclusions from `bowerrc`
   - Exclusions from `gcov-global`
   - Executing `gcov` on `*.gcno`
   - Creating upload text

### Testing

Please see this sample project: https://github.com/reeteshranjan/codecov-node-appveyor-sample. It uses the modified version of `lib/codecov.js` (as in this commit) patched during the build to the local installation of codecov 2.2.0 npm module. Details are as follows:

- Multiple directories and files were created under `win-tests` (in the sample project) to test all the inclusion and exclusion filters.
- A sample `.bowerrc` file is added to test the port of handling exclusions as per `.bowerrc`.
- Sample `C` files were added, which are compiled with `--coverage` and run in the Appveyor build (link provided below). The porting of running `gcov` on the `*.gcno` files created on Windows was verified to include the resultant coverage of these `C` files in codecov.io reports (link provided below).
- Handling exclusions as per `gcov-global` option was verified locally.
- All `nodejs` versions supported by `codecov-node` have been included in the Appveyor build. As per https://www.appveyor.com/docs/lang/nodejs-iojs/#selecting-nodejs-or-iojs-version, the versions included are 7, 6, 5, 4, 0.12 and 1.0 (for iojs one needs to specify 1.0).
- As per http://help.appveyor.com/discussions/questions/372-build-setup-for-a-c-program, MinGW `gcc` is available on Appveyor, and the `appveyor.yml` in this sample project sets the path for `gcov` accordingly. However; the code stays with `gcov` being available on path, or as specified through command line. The `appveyor.yml` in the sample project can be referred to for other users to help them get their builds running on Appveyor.

Appveyor build: https://ci.appveyor.com/project/reeteshranjan/codecov-node-appveyor-sample/build/1.0.8
Successful coverage reports: https://codecov.io/gh/reeteshranjan/codecov-node-appveyor-sample