### PR TITLE
rollback request to v2.77.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/codecov/codecov-node",
   "dependencies": {
-    "request": "2.81.0",
+    "request": "2.77.0",
     "urlgrey": "0.4.4",
     "argv": "0.0.2"
   },


### PR DESCRIPTION
this is the latest version that is still compatible with node <4.0.
fixes #72