### PR TITLE
Use current reuqest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/codecov/codecov-node",
   "dependencies": {
-    "request": "2.77.0",
+    "request": "2.83.0",
     "urlgrey": "0.4.4",
     "argv": "0.0.2"
   },


### PR DESCRIPTION
Changes the version of request to the current one to prevent warning because of deprecated node-uuid package