### PR TITLE
Removed the need for codecov to use git by default

### DIFF
--- a/lib/codecov.js
+++ b/lib/codecov.js
@@ -3,6 +3,8 @@ var path = require('path');
 var request = require('request');
 var urlgrey = require('urlgrey');
 var execSync = require('child_process').execSync;
+var glob = require('glob');
+var gitIgnoreParser = require('gitignore-parser');
 
 var detectProvider = require('./detect');
 
@@ -283,7 +285,11 @@ var upload = function(args, on_success, on_failure){
   // List git files
   var root = path.resolve(args.options.root || query.root || '.');
   console.log('==> Building file structure');
-  upload += execSync('cd '+root+' && git ls-files || hg locate').toString().trim() + '\n<<<<<< network\n';
+
+  var gitignore = gitIgnoreParser.compile(fs.readFileSync('.gitignore', 'utf8'));
+  var gitIncludedFiles = glob.sync('**/*').filter(gitignore.accepts);
+
+  upload += gitIncludedFiles.join('\n').toString().trim() + '\n<<<<<< network\n';
 
   // Make gcov reports
   if ((args.options.disable || '').split(',').indexOf('gcov') === -1) {
@@ -375,7 +381,7 @@ var upload = function(args, on_success, on_failure){
 
   if (files) {
     // Upload to Codecov
-    if (args.options.dump) {
+    if (args.options.dump || true) {
       console.log('-------- DEBUG START --------');
       console.log(upload);
       console.log('-------- DEBUG END --------');

--- a/package.json
+++ b/package.json
@@ -29,9 +29,11 @@
   },
   "homepage": "https://github.com/codecov/codecov-node",
   "dependencies": {
+    "argv": "0.0.2",
+    "gitignore-parser": "0.0.2",
+    "glob": "^7.1.2",
     "request": "2.81.0",
-    "urlgrey": "0.4.4",
-    "argv": "0.0.2"
+    "urlgrey": "0.4.4"
   },
   "devDependencies": {
     "expect.js": "^0.3.1",


### PR DESCRIPTION
I'm looking to use Codecov within a container that does not have git, and as far as I could see the only requirement for it was to get the list of files needed to upload; the branch and commit is pulled from the CI environment variables.

What are your thoughts on using globbing with the git ignore matcher to perform this task instead?

Known issues:
- [ ] Support mg