### PR TITLE
Fix non-portable `find(1)` command

### DIFF
--- a/lib/codecov.js
+++ b/lib/codecov.js
@@ -30,52 +30,52 @@ if (!isWindows) {
     "-or -name 'gcov.info' " +
     "-or -name '*.gcov' " +
     "-or -name '*.lst' \\) " +
-    "-not -name '*.sh' " +
-    "-not -name '*.data' " +
-    "-not -name '*.py' " +
-    "-not -name '*.class' " +
-    "-not -name '*.xcconfig' " +
-    "-not -name 'Coverage.profdata' " +
-    "-not -name 'phpunit-code-coverage.xml' " +
-    "-not -name 'coverage.serialized' " +
-    "-not -name '*.pyc' " +
-    "-not -name '*.cfg' " +
-    "-not -name '*.egg' " +
-    "-not -name '*.whl' " +
-    "-not -name '*.html' " +
-    "-not -name '*.js' " +
-    "-not -name '*.cpp' " +
-    "-not -name 'coverage.jade' " +
-    "-not -name 'include.lst' " +
-    "-not -name 'inputFiles.lst' " +
-    "-not -name 'createdFiles.lst' " +
-    "-not -name 'coverage.html' " +
-    "-not -name 'scoverage.measurements.*' " +
-    "-not -name 'test_*_coverage.txt' " +
-    "-not -path '*/vendor/*' " +
-    "-not -path '*/htmlcov/*' " +
-    "-not -path '*/home/cainus/*' " +
-    "-not -path '*/virtualenv/*' " +
-    "-not -path '*/js/generated/coverage/*' " +
-    "-not -path '*/.virtualenv/*' " +
-    "-not -path '*/virtualenvs/*' " +
-    "-not -path '*/.virtualenvs/*' " +
-    "-not -path '*/.env/*' " +
-    "-not -path '*/.envs/*' " +
-    "-not -path '*/env/*' " +
-    "-not -path '*/envs/*' " +
-    "-not -path '*/.venv/*' " +
-    "-not -path '*/.venvs/*' " +
-    "-not -path '*/venv/*' " +
-    "-not -path '*/venvs/*' " +
-    "-not -path '*/.git/*' " +
-    "-not -path '*/.hg/*' " +
-    "-not -path '*/.tox/*' " +
-    "-not -path '*/__pycache__/*' " +
-    "-not -path '*/.egg-info*' " +
-    "-not -path '*/$bower_components/*' " +
-    "-not -path '*/node_modules/*' " +
-    "-not -path '*/conftest_*.c.gcov'"
+    "\\! \\( -name '*.sh' \\) " +
+    "\\! \\( -name '*.data' \\) " +
+    "\\! \\( -name '*.py' \\) " +
+    "\\! \\( -name '*.class' \\) " +
+    "\\! \\( -name '*.xcconfig' \\) " +
+    "\\! \\( -name 'Coverage.profdata' \\) " +
+    "\\! \\( -name 'phpunit-code-coverage.xml' \\) " +
+    "\\! \\( -name 'coverage.serialized' \\) " +
+    "\\! \\( -name '*.pyc' \\) " +
+    "\\! \\( -name '*.cfg' \\) " +
+    "\\! \\( -name '*.egg' \\) " +
+    "\\! \\( -name '*.whl' \\) " +
+    "\\! \\( -name '*.html' \\) " +
+    "\\! \\( -name '*.js' \\) " +
+    "\\! \\( -name '*.cpp' \\) " +
+    "\\! \\( -name 'coverage.jade' \\) " +
+    "\\! \\( -name 'include.lst' \\) " +
+    "\\! \\( -name 'inputFiles.lst' \\) " +
+    "\\! \\( -name 'createdFiles.lst' \\) " +
+    "\\! \\( -name 'coverage.html' \\) " +
+    "\\! \\( -name 'scoverage.measurements.*' \\) " +
+    "\\! \\( -name 'test_*_coverage.txt' \\) " +
+    "\\! \\( -path '*/vendor/*' \\) " +
+    "\\! \\( -path '*/htmlcov/*' \\) " +
+    "\\! \\( -path '*/home/cainus/*' \\) " +
+    "\\! \\( -path '*/virtualenv/*' \\) " +
+    "\\! \\( -path '*/js/generated/coverage/*' \\) " +
+    "\\! \\( -path '*/.virtualenv/*' \\) " +
+    "\\! \\( -path '*/virtualenvs/*' \\) " +
+    "\\! \\( -path '*/.virtualenvs/*' \\) " +
+    "\\! \\( -path '*/.env/*' \\) " +
+    "\\! \\( -path '*/.envs/*' \\) " +
+    "\\! \\( -path '*/env/*' \\) " +
+    "\\! \\( -path '*/envs/*' \\) " +
+    "\\! \\( -path '*/.venv/*' \\) " +
+    "\\! \\( -path '*/.venvs/*' \\) " +
+    "\\! \\( -path '*/venv/*' \\) " +
+    "\\! \\( -path '*/venvs/*' \\) " +
+    "\\! \\( -path '*/.git/*' \\) " +
+    "\\! \\( -path '*/.hg/*' \\) " +
+    "\\! \\( -path '*/.tox/*' \\) " +
+    "\\! \\( -path '*/__pycache__/*' \\) " +
+    "\\! \\( -path '*/.egg-info*' \\) " +
+    "\\! \\( -path '*/$bower_components/*' \\) " +
+    "\\! \\( -path '*/node_modules/*' \\) " +
+    "\\! \\( -path '*/conftest_*.c.gcov' \\)";
 } else {
   patterns =
     '/a-d /b /s *coverage.* ' +


### PR DESCRIPTION
The `-not` flag to find isn't portable outside of Linux and macOS.
This fixes support for various BSD's by using the `!` operator.