### PR TITLE
Stop outputting upload-token in logs

### DIFF
--- a/lib/codecov.js
+++ b/lib/codecov.js
@@ -261,7 +261,12 @@ var upload = function(args, on_success, on_failure){
 
   console.log("==> Configuration: ");
   console.log("    Endpoint: " + codecov_endpoint);
-  console.log(query);
+  // Don't output `query` directly as it contains the upload token
+  console.log({
+    commit: query.commit,
+    branch: query.branch,
+    package: query.package
+  });
 
   var upload = "";
 


### PR DESCRIPTION
Instead of dumping `query` object directly, output a selected set of values (don't output the upload_token)

Introduced in https://github.com/codecov/codecov-node/commit/4be417139da5d3ac98272bf770fa7980b51032d6

Closes https://github.com/codecov/codecov-node/issues/94