### PR TITLE
Allow custom `yaml` file.

### DIFF
--- a/bin/codecov
+++ b/bin/codecov
@@ -20,7 +20,8 @@ var args = argv.option([
   {name: 'slug', short: 'r', type: 'string', description: "Specify repository slug for Enterprise ex. owner/repo"},
   {name: 'url', short: 'u', type: 'string', description: "Your Codecov endpoint"},
   {name: 'flags', short: 'F', type: 'string', description: "Codecov Flags"},
-  {name: 'dump', type: 'boolean', description: "Dump collected data and do not send to Codecov"}
+  {name: 'dump', type: 'boolean', description: "Dump collected data and do not send to Codecov"},
+  {name: 'y', type: 'string', description: "Configuration file Used to specify the location of the .codecov.yml config file. Defaults to codecov.yml and .codecov.yml"}
 ]).run();
 
 codecov.upload(args);

--- a/bin/codecov
+++ b/bin/codecov
@@ -21,7 +21,7 @@ var args = argv.option([
   {name: 'url', short: 'u', type: 'string', description: "Your Codecov endpoint"},
   {name: 'flags', short: 'F', type: 'string', description: "Codecov Flags"},
   {name: 'dump', type: 'boolean', description: "Dump collected data and do not send to Codecov"},
-  {name: 'y', type: 'string', description: "Configuration file Used to specify the location of the .codecov.yml config file. Defaults to codecov.yml and .codecov.yml"}
+  {name: 'yml', short: 'y', type: 'string', description: "Configuration file Used to specify the location of the .codecov.yml config file. Defaults to codecov.yml and .codecov.yml"}
 ]).run();
 
 codecov.upload(args);

--- a/lib/codecov.js
+++ b/lib/codecov.js
@@ -241,7 +241,10 @@ var upload = function(args, on_success, on_failure) {
   var query = {}
   var debug = []
   var yamlFile =
-    process.env.codecov_yml || process.env.CODECOV_YML || 'codecov.yml'
+    args.options.yml ||
+    process.env.codecov_yml ||
+    process.env.CODECOV_YML ||
+    'codecov.yml'
 
   console.log(
     '' +

--- a/lib/codecov.js
+++ b/lib/codecov.js
@@ -241,7 +241,7 @@ var upload = function(args, on_success, on_failure) {
   var query = {}
   var debug = []
   var yamlFile =
-    args.options.y ||
+    args.options.yml ||
     process.env.codecov_yml ||
     process.env.CODECOV_YML ||
     'codecov.yml'

--- a/lib/codecov.js
+++ b/lib/codecov.js
@@ -241,7 +241,7 @@ var upload = function(args, on_success, on_failure) {
   var query = {}
   var debug = []
   var yamlFile =
-    args.options.yml ||
+    args.options.y ||
     process.env.codecov_yml ||
     process.env.CODECOV_YML ||
     'codecov.yml'

--- a/lib/codecov.js
+++ b/lib/codecov.js
@@ -240,6 +240,8 @@ var upload = function(args, on_success, on_failure) {
     'https://codecov.io'
   var query = {}
   var debug = []
+  var yamlFile =
+    process.env.codecov_yml || process.env.CODECOV_YML || 'codecov.yml'
 
   console.log(
     '' +
@@ -253,7 +255,7 @@ var upload = function(args, on_success, on_failure) {
       version
   )
 
-  query.yaml = ['codecov.yml', '.codecov.yml'].reduce(function(result, file) {
+  query.yaml = [yamlFile, '.codecov.yml'].reduce(function(result, file) {
     return (
       result ||
       (fs.existsSync(path.resolve(process.cwd(), file)) ? file : undefined)

--- a/test/index.js
+++ b/test/index.js
@@ -161,4 +161,25 @@ describe('Codecov', function() {
     var version = require('../package.json').version
     expect(codecov.version).to.eql('v' + version)
   })
+
+  it('Should use codecov.yml via env variable', function() {
+    expect(
+      codecov.upload({ options: { dump: true, disable: 'detect' } }).query.yaml
+    ).to.eql('codecov.yml')
+
+    fs.writeFileSync('foo.yml', '')
+    process.env.codecov_yml = 'foo.yml'
+    expect(
+      codecov.upload({ options: { dump: true, disable: 'detect' } }).query.yaml
+    ).to.eql('foo.yml')
+    fs.unlinkSync('foo.yml')
+    delete process.env.codecov_yml
+
+    fs.writeFileSync('FOO.yml', '')
+    process.env.CODECOV_YML = 'FOO.yml'
+    expect(
+      codecov.upload({ options: { dump: true, disable: 'detect' } }).query.yaml
+    ).to.eql('FOO.yml')
+    fs.unlinkSync('FOO.yml')
+  })
 })

--- a/test/index.js
+++ b/test/index.js
@@ -181,5 +181,6 @@ describe('Codecov', function() {
       codecov.upload({ options: { dump: true, disable: 'detect' } }).query.yaml
     ).to.eql('FOO.yml')
     fs.unlinkSync('FOO.yml')
+    delete process.env.CODECOV_YML
   })
 })

--- a/test/index.js
+++ b/test/index.js
@@ -187,7 +187,7 @@ describe('Codecov', function() {
   it('can get config from cli args', function() {
     fs.writeFileSync('foo.yml', '')
     var res = codecov.upload({
-      options: { dump: true, y: 'foo.yml', disable: 'detect' },
+      options: { dump: true, yml: 'foo.yml', disable: 'detect' },
     })
     expect(res.query.yaml).to.eql('foo.yml')
     fs.unlinkSync('foo.yml')

--- a/test/index.js
+++ b/test/index.js
@@ -187,7 +187,7 @@ describe('Codecov', function() {
   it('can get config from cli args', function() {
     fs.writeFileSync('foo.yml', '')
     var res = codecov.upload({
-      options: { dump: true, yml: 'foo.yml', disable: 'detect' },
+      options: { dump: true, y: 'foo.yml', disable: 'detect' },
     })
     expect(res.query.yaml).to.eql('foo.yml')
     fs.unlinkSync('foo.yml')

--- a/test/index.js
+++ b/test/index.js
@@ -183,4 +183,13 @@ describe('Codecov', function() {
     fs.unlinkSync('FOO.yml')
     delete process.env.CODECOV_YML
   })
+
+  it('can get config from cli args', function() {
+    fs.writeFileSync('foo.yml', '')
+    var res = codecov.upload({
+      options: { dump: true, yml: 'foo.yml', disable: 'detect' },
+    })
+    expect(res.query.yaml).to.eql('foo.yml')
+    fs.unlinkSync('foo.yml')
+  })
 })


### PR DESCRIPTION
## Description
Enables custom `yaml` files or locations.

## Motivation
I'm working in a monorepo architecture with a file structure like
```
├── package.json
├── codecov.yaml
└── packages
    ├── foo
    │   └── package.json
    └── bar
          └── package.json

```

The main `package.json` starts the codecov process, but is not aware of any unit test. It's using `lerna` so each package.json will run independently.

The main `package.json` contains
```json
{
  "scripts": {
    "lerna": "lerna",
    "codecov": "CODECOV_TOKEN=some-token CODECOV_YAML=codecov.yaml lerna run codecov"
  }
}
```

And each of the `packages` package.json contains the following
```json
{
  "scripts": {
    "codecov": "codecov --flags=\"foo\""
  }
}
```

I'm still figuring out a good approach for all of this. But having custom `yaml` files would be handy for other use cases I think 😄 

_Update:_

As suggested by @eddiemoore. This is also possible by a flag in cli.

```sh
codecov --yml=foo.yml
codecov -y foo.yml
```