### PR TITLE
 fix: support `.codecov.yml`/`codecov.yml` files for token

### DIFF
--- a/lib/codecov.js
+++ b/lib/codecov.js
@@ -2,6 +2,7 @@ var fs = require('fs')
 var path = require('path')
 var request = require('request')
 var urlgrey = require('urlgrey')
+var jsYaml = require('js-yaml')
 var walk = require('ignore-walk')
 var execSync = require('child_process').execSync
 
@@ -258,19 +259,21 @@ var upload = function(args, on_success, on_failure) {
       version
   )
 
-  query.yaml = [yamlFile, '.codecov.yml'].reduce(function(result, file) {
-    return (
-      result ||
-      (fs.existsSync(path.resolve(process.cwd(), file)) ? file : undefined)
-    )
-  }, undefined)
-
   if ((args.options.disable || '').split(',').indexOf('detect') === -1) {
     console.log('==> Detecting CI Provider')
     query = detectProvider()
   } else {
     debug.push('disabled detect')
   }
+
+  query.yaml = [yamlFile, '.codecov.yml'].reduce(function(result, file) {
+    return (
+      result ||
+      (fs.existsSync(path.resolve(process.cwd(), file))
+        ? path.resolve(process.cwd(), file)
+        : undefined)
+    )
+  }, undefined)
 
   if (args.options.build) {
     query.build = args.options.build
@@ -294,8 +297,18 @@ var upload = function(args, on_success, on_failure) {
     query.flags = flags
   }
 
+  var yamlToken
+  try {
+    var loadedYamlFile  = jsYaml.safeLoad(fs.readFileSync(query.yaml, 'utf8'))
+    yamlToken = loadedYamlFile && loadedYamlFile.codecov && loadedYamlFile.codecov.token
+  } catch (e) {
+    // silently fail
+  }
   var token =
-    args.options.token || process.env.codecov_token || process.env.CODECOV_TOKEN
+    args.options.token ||
+    yamlToken ||
+    process.env.codecov_token ||
+    process.env.CODECOV_TOKEN
   if (token) {
     query.token = token
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -230,7 +230,6 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity":
         "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
       "requires": {
         "sprintf-js": "1.0.3"
       }
@@ -1062,6 +1061,12 @@
         "acorn": "5.7.1",
         "acorn-jsx": "3.0.1"
       }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity":
+        "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "esquery": {
       "version": "1.0.1",
@@ -2093,19 +2098,9 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
       "integrity":
         "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
-      "dev": true,
       "requires": {
         "argparse": "1.0.10",
-        "esprima": "4.0.0"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-          "integrity":
-            "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-          "dev": true
-        }
+        "esprima": "4.0.1"
       }
     },
     "jsbn": {
@@ -2631,6 +2626,13 @@
           }
         }
       }
+    },
+    "mock-fs": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.6.0.tgz",
+      "integrity":
+        "sha512-aYutNIwFaMsVgtMoc5vMsobA/yRJR2FTUFoTZgnjdb3gID0g8WMmeafWmHPgzKgZ7zwQ5kggYUgeq5sN9k9uDw==",
+      "dev": true
     },
     "ms": {
       "version": "2.0.0",
@@ -5513,8 +5515,7 @@
       "version": "1.0.3",
       "resolved":
         "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
       "version": "1.14.2",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "argv": "^0.0.2",
     "ignore-walk": "^3.0.1",
+    "js-yaml": "^3.12.0",
     "request": "^2.87.0",
     "urlgrey": "^0.4.4"
   },
@@ -38,6 +39,7 @@
     "husky": "^0.14.3",
     "lint-staged": "^7.2.0",
     "mocha": "^5.2.0",
+    "mock-fs": "^4.6.0",
     "nyc": "^12.0.2",
     "prettier": "^1.13.7"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -30,6 +30,7 @@ describe('Codecov', function() {
     expect(codecov.upload({ options: { dump: true } }).query.token).to.eql(
       'ABC123'
     )
+    delete process.env.CODECOV_TOKEN
   })
 
   it('can get a token passed in cli', function() {
@@ -189,6 +190,7 @@ describe('Codecov', function() {
     var res = codecov.upload({ options: { dump: true, env: 'HELLO,VAR1' } })
     expect(res.body).to.contain('HELLO=world\n')
     expect(res.body).to.contain('VAR1=\n')
+    delete process.env.HELLO
   })
 
   it('can include env in env', function() {
@@ -198,6 +200,8 @@ describe('Codecov', function() {
     expect(res.body).to.contain('HELLO=world\n')
     expect(res.body).to.contain('VAR1=\n')
     expect(res.body).to.contain('VAR2=\n')
+    delete process.env.HELLO
+    delete process.env.CODECOV_ENV
   })
 
   it('can have custom args for gcov', function() {

--- a/test/index.js
+++ b/test/index.js
@@ -231,33 +231,40 @@ describe('Codecov', function() {
   })
 
   it('Should use codecov.yml via env variable', function() {
+    var CWD = process.cwd()
     expect(
       codecov.upload({ options: { dump: true, disable: 'detect' } }).query.yaml
-    ).to.eql('codecov.yml')
+    ).to.eql(CWD + '/codecov.yml')
 
-    fs.writeFileSync('foo.yml', '')
+    mockFs({
+      'foo.yml': '',
+    })
     process.env.codecov_yml = 'foo.yml'
     expect(
       codecov.upload({ options: { dump: true, disable: 'detect' } }).query.yaml
-    ).to.eql('foo.yml')
-    fs.unlinkSync('foo.yml')
+    ).to.eql(CWD + '/foo.yml')
+    mockFs.restore()
     delete process.env.codecov_yml
 
-    fs.writeFileSync('FOO.yml', '')
+    mockFs({
+      'FOO.yml': '',
+    })
     process.env.CODECOV_YML = 'FOO.yml'
     expect(
       codecov.upload({ options: { dump: true, disable: 'detect' } }).query.yaml
-    ).to.eql('FOO.yml')
-    fs.unlinkSync('FOO.yml')
+    ).to.eql(CWD + '/FOO.yml')
+    mockFs.restore()
     delete process.env.CODECOV_YML
   })
 
   it('can get config from cli args', function() {
-    fs.writeFileSync('foo.yml', '')
+    mockFs({
+      'foo.yml': '',
+    })
     var res = codecov.upload({
       options: { dump: true, yml: 'foo.yml', disable: 'detect' },
     })
-    expect(res.query.yaml).to.eql('foo.yml')
-    fs.unlinkSync('foo.yml')
+    expect(res.query.yaml).to.eql(process.cwd() + '/foo.yml')
+    mockFs.restore()
   })
 })

--- a/test/services/gitlab.js
+++ b/test/services/gitlab.js
@@ -6,6 +6,11 @@ describe('Gitlab CI Provider', function() {
     expect(gitlab.detect()).to.be(true)
   })
 
+  it('cannot detect gitlab', function() {
+    delete process.env.GITLAB_CI
+    expect(gitlab.detect()).to.be(false)
+  })
+
   it('can get service env info', function() {
     process.env.CI_BUILD_ID = '1234'
     process.env.CI_BUILD_REPO = 'https://gitlab.com/owner/repo.git'
@@ -18,6 +23,25 @@ describe('Gitlab CI Provider', function() {
       root: '/',
       commit: '5678',
       slug: 'owner/repo',
+      branch: 'master',
+    })
+    delete process.env.CI_BUILD_REPO
+    process.env.CI_REPOSITORY_URL = 'https://gitlab.com/owner/repo2.git'
+    expect(gitlab.configuration()).to.eql({
+      service: 'gitlab',
+      build: '1234',
+      root: '/',
+      commit: '5678',
+      slug: 'owner/repo2',
+      branch: 'master',
+    })
+    delete process.env.CI_REPOSITORY_URL
+    expect(gitlab.configuration()).to.eql({
+      service: 'gitlab',
+      build: '1234',
+      root: '/',
+      commit: '5678',
+      slug: '',
       branch: 'master',
     })
   })


### PR DESCRIPTION
currently, `<rootDir>/.codecov.yml` and `<rootDir>/.codecov.yml` are not recognized by this node package. it looks like `query.yaml` was getting blown away when `query = detectProvider()` was called since currently `query.yaml` is assigned above it. 

I moved the `query.yaml` assignment after the `query = detectProvider()` call to maintain the yaml file reference.