### PR TITLE
FIX: NODE-SECURITY-813: js-yaml < 3.13.1 code injection

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "argv": "^0.0.2",
     "ignore-walk": "^3.0.1",
-    "js-yaml": "^3.13.0",
+    "js-yaml": "^3.13.1",
     "teeny-request": "^3.11.3",
     "urlgrey": "^0.4.4"
   },


### PR DESCRIPTION
Addresses the following [CVE](https://www.npmjs.com/advisories/813).