### PR TITLE
Updates Semaphore CI Service for 2.0

### DIFF
--- a/lib/services/semaphore.js
+++ b/lib/services/semaphore.js
@@ -7,8 +7,9 @@ module.exports = {
     console.log('    Semaphore CI Detected')
     return {
       service: 'semaphore',
-      commit: process.env.SEMAPHORE_GIT_SHA,
       branch: process.env.SEMAPHORE_GIT_BRANCH,
+      build: process.env.SEMAPHORE_WORKFLOW_ID,
+      commit: process.env.SEMAPHORE_GIT_SHA,
     }
   },
 }

--- a/lib/services/semaphore.js
+++ b/lib/services/semaphore.js
@@ -7,13 +7,8 @@ module.exports = {
     console.log('    Semaphore CI Detected')
     return {
       service: 'semaphore',
-      build:
-        process.env.SEMAPHORE_BUILD_NUMBER +
-        '.' +
-        process.env.SEMAPHORE_CURRENT_THREAD,
-      commit: process.env.REVISION,
-      branch: process.env.BRANCH_NAME,
-      slug: process.env.SEMAPHORE_REPO_SLUG,
+      commit: process.env.SEMAPHORE_GIT_SHA,
+      branch: process.env.SEMAPHORE_GIT_BRANCH,
     }
   },
 }

--- a/test/services/semaphore.test.js
+++ b/test/services/semaphore.test.js
@@ -7,12 +7,14 @@ describe('Semaphore CI Provider', function() {
   })
 
   it('can get semaphore env info', function() {
-    process.env.SEMAPHORE_GIT_SHA = '5c84719708b9b649b9ef3b56af214f38cee6acde'
     process.env.SEMAPHORE_GIT_BRANCH = 'development'
+    process.env.SEMAPHORE_GIT_SHA = '5c84719708b9b649b9ef3b56af214f38cee6acde'
+    process.env.SEMAPHORE_WORKFLOW_ID = '65c9bb1c-aeb6-41f0-b8d9-6fa177241cdf'
     expect(semaphore.configuration()).toEqual({
       service: 'semaphore',
-      commit: '5c84719708b9b649b9ef3b56af214f38cee6acde',
       branch: 'development',
+      build: '65c9bb1c-aeb6-41f0-b8d9-6fa177241cdf',
+      commit: '5c84719708b9b649b9ef3b56af214f38cee6acde',
     })
   })
 })

--- a/test/services/semaphore.test.js
+++ b/test/services/semaphore.test.js
@@ -7,17 +7,12 @@ describe('Semaphore CI Provider', function() {
   })
 
   it('can get semaphore env info', function() {
-    process.env.SEMAPHORE_BUILD_NUMBER = '1234'
-    process.env.REVISION = '5678'
-    process.env.SEMAPHORE_CURRENT_THREAD = '1'
-    process.env.BRANCH_NAME = 'master'
-    process.env.SEMAPHORE_REPO_SLUG = 'owner/repo'
+    process.env.SEMAPHORE_GIT_SHA = '5c84719708b9b649b9ef3b56af214f38cee6acde'
+    process.env.SEMAPHORE_GIT_BRANCH = 'development'
     expect(semaphore.configuration()).toEqual({
       service: 'semaphore',
-      commit: '5678',
-      build: '1234.1',
-      branch: 'master',
-      slug: 'owner/repo',
+      commit: '5c84719708b9b649b9ef3b56af214f38cee6acde',
+      branch: 'development',
     })
   })
 })


### PR DESCRIPTION
Semaphore launched their 2.0 on November 6th 2018. The current Semaphore Service is using environment variables no longer present with Semaphore 2.0. I've purposefully removed the `build` and `slug` tags from the generated config as there is no good equivalent with Semaphore 2.0 anymore. List of 'git env vars' can be found [here](https://docs.semaphoreci.com/article/12-environment-variables).

If the `build` and/or `slug` tag is needed, I will find a suitable way of extracting them from the environment variables provided.