### PR TITLE
fix: return correct exit codes if successful

### DIFF
--- a/bin/codecov
+++ b/bin/codecov
@@ -25,6 +25,14 @@ var args = argv.option([
   {name: 'yml', short: 'y', type: 'string', description: "Configuration file Used to specify the location of the .codecov.yml config file. Defaults to codecov.yml and .codecov.yml"},
 ]).run();
 
+var handleSuccess = function() {
+  process.exit(0);
+}
+
+var handleFailure = function () {
+  process.exit(1);
+}
+
 if (args.options.pipe) {
   process.stdin.setEncoding('utf8');
   args.options.pipe = [];
@@ -34,8 +42,8 @@ if (args.options.pipe) {
   });
 
   process.stdin.on('end', function() {
-    codecov.upload(args);
+    codecov.upload(args, handleSuccess, handleFailure);
   });
 } else {
-  codecov.upload(args);
+  codecov.upload(args, handleSuccess, handleFailure);
 }


### PR DESCRIPTION
Should be pretty self explaining. Now once an error happens a exit code 1 will be returned. So on Travis or GitHub Actions the build will fail.