### PR TITLE
Add retro-compatibility for Semaphore 1.x and maintain support for 2.x

### DIFF
--- a/lib/detect.js
+++ b/lib/detect.js
@@ -10,10 +10,11 @@ var services = {
   wercker: require('./services/wercker'),
   jenkins: require('./services/jenkins'),
   semaphore: require('./services/semaphore'),
+  semaphore2x: require('./services/semaphore2x'),
   snap: require('./services/snap'),
   gitlab: require('./services/gitlab'),
   heroku: require('./services/heroku'),
-  teamcity: require('./services/teamcity')
+  teamcity: require('./services/teamcity'),
 }
 
 var detectProvider = function() {

--- a/lib/services/semaphore.js
+++ b/lib/services/semaphore.js
@@ -7,9 +7,13 @@ module.exports = {
     console.log('    Semaphore CI Detected')
     return {
       service: 'semaphore',
-      branch: process.env.SEMAPHORE_GIT_BRANCH,
-      build: process.env.SEMAPHORE_WORKFLOW_ID,
-      commit: process.env.SEMAPHORE_GIT_SHA,
+      build:
+        process.env.SEMAPHORE_BUILD_NUMBER +
+        '.' +
+        process.env.SEMAPHORE_CURRENT_THREAD,
+      commit: process.env.REVISION,
+      branch: process.env.BRANCH_NAME,
+      slug: process.env.SEMAPHORE_REPO_SLUG,
     }
   },
 }

--- a/lib/services/semaphore.js
+++ b/lib/services/semaphore.js
@@ -1,12 +1,12 @@
 module.exports = {
   detect: function() {
-    return !!process.env.SEMAPHORE
+    return !!process.env.SEMAPHORE && !!process.env.SEMAPHORE_REPO_SLUG
   },
 
   configuration: function() {
-    console.log('    Semaphore CI Detected')
+    console.log('    Semaphore 1.x CI Detected')
     return {
-      service: 'semaphore',
+      service: 'semaphore1x',
       build:
         process.env.SEMAPHORE_BUILD_NUMBER +
         '.' +

--- a/lib/services/semaphore2x.js
+++ b/lib/services/semaphore2x.js
@@ -1,0 +1,15 @@
+module.exports = {
+  detect: function() {
+    return !!process.env.SEMAPHORE && !!process.env.SEMAPHORE_WORKFLOW_ID
+  },
+
+  configuration: function() {
+    console.log('    Semaphore 2.x CI Detected')
+    return {
+      service: 'semaphore2x',
+      branch: process.env.SEMAPHORE_GIT_BRANCH,
+      build: process.env.SEMAPHORE_WORKFLOW_ID,
+      commit: process.env.SEMAPHORE_GIT_SHA,
+    }
+  },
+}

--- a/test/services/semaphore.test.js
+++ b/test/services/semaphore.test.js
@@ -7,14 +7,17 @@ describe('Semaphore CI Provider', function() {
   })
 
   it('can get semaphore env info', function() {
-    process.env.SEMAPHORE_GIT_BRANCH = 'development'
-    process.env.SEMAPHORE_GIT_SHA = '5c84719708b9b649b9ef3b56af214f38cee6acde'
-    process.env.SEMAPHORE_WORKFLOW_ID = '65c9bb1c-aeb6-41f0-b8d9-6fa177241cdf'
+    process.env.SEMAPHORE_BUILD_NUMBER = '1234'
+    process.env.REVISION = '5678'
+    process.env.SEMAPHORE_CURRENT_THREAD = '1'
+    process.env.BRANCH_NAME = 'master'
+    process.env.SEMAPHORE_REPO_SLUG = 'owner/repo'
     expect(semaphore.configuration()).toEqual({
       service: 'semaphore',
-      branch: 'development',
-      build: '65c9bb1c-aeb6-41f0-b8d9-6fa177241cdf',
-      commit: '5c84719708b9b649b9ef3b56af214f38cee6acde',
+      commit: '5678',
+      build: '1234.1',
+      branch: 'master',
+      slug: 'owner/repo',
     })
   })
 })

--- a/test/services/semaphore.test.js
+++ b/test/services/semaphore.test.js
@@ -1,9 +1,26 @@
 var semaphore = require('../../lib/services/semaphore')
 
 describe('Semaphore CI Provider', function() {
+  var OLD_ENV = process.env
+
+  beforeEach(function() {
+    process.env = Object.assign({}, OLD_ENV)
+  })
+
+  afterEach(function() {
+    process.env = Object.assign({}, OLD_ENV)
+  })
+
   it('can detect semaphore', function() {
     process.env.SEMAPHORE = 'true'
+    process.env.SEMAPHORE_REPO_SLUG = 'owner/repo'
     expect(semaphore.detect()).toBe(true)
+  })
+
+  it('does not detect semaphore 2.x', function() {
+    process.env.SEMAPHORE = 'true'
+    process.env.SEMAPHORE_WORKFLOW_ID = '65c9bb1c-aeb6-41f0-b8d9-6fa177241cdf'
+    expect(semaphore.detect()).toBe(false)
   })
 
   it('can get semaphore env info', function() {
@@ -13,7 +30,7 @@ describe('Semaphore CI Provider', function() {
     process.env.BRANCH_NAME = 'master'
     process.env.SEMAPHORE_REPO_SLUG = 'owner/repo'
     expect(semaphore.configuration()).toEqual({
-      service: 'semaphore',
+      service: 'semaphore1x',
       commit: '5678',
       build: '1234.1',
       branch: 'master',

--- a/test/services/semaphore2x.test.js
+++ b/test/services/semaphore2x.test.js
@@ -1,4 +1,4 @@
-var semaphore = require('../../lib/services/semaphore2x')
+var semaphore2 = require('../../lib/services/semaphore2x')
 
 describe('Semaphore 2.x CI Provider', function() {
   var OLD_ENV = process.env
@@ -14,20 +14,20 @@ describe('Semaphore 2.x CI Provider', function() {
   it('can detect semaphore 2x', function() {
     process.env.SEMAPHORE = 'true'
     process.env.SEMAPHORE_WORKFLOW_ID = '65c9bb1c-aeb6-41f0-b8d9-6fa177241cdf'
-    expect(semaphore.detect()).toBe(true)
+    expect(semaphore2.detect()).toBe(true)
   })
 
   it('does not detect semaphore 1.x', function() {
     process.env.SEMAPHORE = 'true'
     process.env.SEMAPHORE_REPO_SLUG = 'owner/repo'
-    expect(semaphore.detect()).toBe(false)
+    expect(semaphore2.detect()).toBe(false)
   })
 
   it('can get semaphore env info', function() {
     process.env.SEMAPHORE_GIT_BRANCH = 'development'
     process.env.SEMAPHORE_GIT_SHA = '5c84719708b9b649b9ef3b56af214f38cee6acde'
     process.env.SEMAPHORE_WORKFLOW_ID = '65c9bb1c-aeb6-41f0-b8d9-6fa177241cdf'
-    expect(semaphore.configuration()).toEqual({
+    expect(semaphore2.configuration()).toEqual({
       service: 'semaphore2x',
       branch: 'development',
       build: '65c9bb1c-aeb6-41f0-b8d9-6fa177241cdf',

--- a/test/services/semaphore2x.test.js
+++ b/test/services/semaphore2x.test.js
@@ -1,0 +1,37 @@
+var semaphore = require('../../lib/services/semaphore2x')
+
+describe('Semaphore 2.x CI Provider', function() {
+  var OLD_ENV = process.env
+
+  beforeEach(function() {
+    process.env = Object.assign({}, OLD_ENV)
+  })
+
+  afterEach(function() {
+    process.env = Object.assign({}, OLD_ENV)
+  })
+
+  it('can detect semaphore 2x', function() {
+    process.env.SEMAPHORE = 'true'
+    process.env.SEMAPHORE_WORKFLOW_ID = '65c9bb1c-aeb6-41f0-b8d9-6fa177241cdf'
+    expect(semaphore.detect()).toBe(true)
+  })
+
+  it('does not detect semaphore 1.x', function() {
+    process.env.SEMAPHORE = 'true'
+    process.env.SEMAPHORE_REPO_SLUG = 'owner/repo'
+    expect(semaphore.detect()).toBe(false)
+  })
+
+  it('can get semaphore env info', function() {
+    process.env.SEMAPHORE_GIT_BRANCH = 'development'
+    process.env.SEMAPHORE_GIT_SHA = '5c84719708b9b649b9ef3b56af214f38cee6acde'
+    process.env.SEMAPHORE_WORKFLOW_ID = '65c9bb1c-aeb6-41f0-b8d9-6fa177241cdf'
+    expect(semaphore.configuration()).toEqual({
+      service: 'semaphore2x',
+      branch: 'development',
+      build: '65c9bb1c-aeb6-41f0-b8d9-6fa177241cdf',
+      commit: '5c84719708b9b649b9ef3b56af214f38cee6acde',
+    })
+  })
+})


### PR DESCRIPTION
## Why
#132 removes compatibility with `Semaphore 1.x`.
This PR brings back compatibility with `Semaphore 1.x` and maintain the support for `Semaphore 2.x`.

Once merged it would reduce the risk of publishing a new `codecov-node` version and actually make the support `Semaphore 2.x` public.

## What
- Bring back support for `Semaphore 1.x`
- Keep support for Semaphore `2.x`
- Make sure `codecov-node` is able to distinguish the versions

## How
- Revert #132
- Detect Semaphore 1.x using the presence of `SEMAPHORE_REPO_SLUG` (not available in Semaphore 2.x)
- Detect Semaphore 2.x using the presence of `SEMAPHORE_WORKFLOW_ID` (not available in Semaphore 1.x)
- Add tests