### PR TITLE
Handle builds triggered by AWS SDK.

### DIFF
--- a/lib/services/codebuild.js
+++ b/lib/services/codebuild.js
@@ -1,3 +1,5 @@
+var git = require('../git.js')
+
 module.exports = {
   detect: function() {
     return !!process.env.CODEBUILD_CI
@@ -21,13 +23,13 @@ module.exports = {
           ''
         )
       }
-      throw new Error('Cannot detect branch name.')
+      return git.branch()
     }
     function detectPRNumber() {
-      if (process.env.CODEBUILD_SOURCE_VERSION) {
+      if (process.env.CODEBUILD_WEBHOOK_HEAD_REF) {
         return process.env.CODEBUILD_SOURCE_VERSION.replace(/^pr\//, '')
       }
-      throw new Error('Cannot detect PR number.')
+      return undefined
     }
     function detectRepoSlug() {
       if (process.env.CODEBUILD_SOURCE_REPO_URL) {


### PR DESCRIPTION
Introduction
------------
Codebuild can be triggered by webhooks, or by resources inside the AWS cloud environment (such as lambda) via the AWS SDK. Upon triggering builds with the SDK inside Lambda, I was receiving the error documented inside https://github.com/codecov/codecov-node/issues/148. The intent of this PR is to resolve the issue.

Changelog
-----------
1. `lib/services/codebuild.js`
    * Use git to find branch if not triggered by webhooks. 
    * Send undefined pull request # if not triggered by webhook.
2. `test/services/codebuild.test.js`
    * Add tests that mock git functionality.