### PR TITLE
Add Github Actions support

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,10 +1,9 @@
 name: Node CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     strategy:
@@ -12,7 +11,7 @@ jobs:
         node-version: [10.x, 12.x, 14.x]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:
@@ -24,3 +23,5 @@ jobs:
         npm test
       env:
         CI: true
+    - name: Upload coverage to Codecov
+      run: ./bin/codecov

--- a/lib/detect.js
+++ b/lib/detect.js
@@ -16,6 +16,7 @@ var services = {
   heroku: require('./services/heroku'),
   teamcity: require('./services/teamcity'),
   codebuild: require('./services/codebuild'),
+  github_actions: require('./services/github_actions'),
 }
 
 var detectProvider = function() {

--- a/lib/services/github_actions.js
+++ b/lib/services/github_actions.js
@@ -1,15 +1,27 @@
 module.exports = {
-    detect: function() {
-      return !!process.env.GITHUB_ACTIONS
-    },
-  
-    configuration: function() {
-      console.log('    GitHub Actions CI Detected')
-      return {
-        service: 'github-actions',
-        commit: process.env.GITHUB_SHA,
-        branch: process.env.GITHUB_REF.replace("refs/heads/", ""),
-        slug: process.env.GITHUB_REPOSITORY,
-      }
-    },
-  }
+  detect: function() {
+    return !!process.env.GITHUB_ACTIONS
+  },
+
+  configuration: function() {
+    // https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables
+    console.log('    GitHub Actions CI Detected')
+
+    var params = {
+      branch:
+        process.env.GITHUB_HEAD_REF ||
+        process.env.GITHUB_REF.replace('refs/heads/', ''),
+      build: process.env.GITHUB_RUN_ID,
+      commit: process.env.GITHUB_SHA,
+      service: 'github-actions',
+      slug: process.env.GITHUB_REPOSITORY,
+    }
+
+    if (process.env.GITHUB_HEAD_REF) {
+      // PR refs are in the format: refs/pull/7/merge for pull_request events
+      params['pr'] = process.env.GITHUB_REF.split('/')[2]
+    }
+
+    return params
+  },
+}

--- a/lib/services/github_actions.js
+++ b/lib/services/github_actions.js
@@ -1,0 +1,20 @@
+module.exports = {
+    detect: () => {
+      return !!process.env.GITHUB_ACTIONS
+    },
+  
+    configuration: () => {
+      console.log('    GitHub Actions CI Detected')
+      return {
+        service: 'github_actions',
+        commit: process.env.GITHUB_SHA,
+        branch: getBranch(),
+        slug: process.env.GITHUB_REPOSITORY,
+      }
+
+      getBranch = () => {
+        let currRef = process.env.GITHUB_REF
+        return currRef.replace("refs/heads/", "")
+      }
+    },
+  }

--- a/lib/services/github_actions.js
+++ b/lib/services/github_actions.js
@@ -6,7 +6,7 @@ module.exports = {
     configuration: function() {
       console.log('    GitHub Actions CI Detected')
       return {
-        service: 'github_actions',
+        service: 'github-actions',
         commit: process.env.GITHUB_SHA,
         branch: process.env.GITHUB_REF.replace("refs/heads/", ""),
         slug: process.env.GITHUB_REPOSITORY,

--- a/lib/services/github_actions.js
+++ b/lib/services/github_actions.js
@@ -1,20 +1,15 @@
 module.exports = {
-    detect: () => {
+    detect: function() {
       return !!process.env.GITHUB_ACTIONS
     },
   
-    configuration: () => {
+    configuration: function() {
       console.log('    GitHub Actions CI Detected')
       return {
         service: 'github_actions',
         commit: process.env.GITHUB_SHA,
-        branch: getBranch(),
+        branch: process.env.GITHUB_REF.replace("refs/heads/", ""),
         slug: process.env.GITHUB_REPOSITORY,
-      }
-
-      getBranch = () => {
-        let currRef = process.env.GITHUB_REF
-        return currRef.replace("refs/heads/", "")
       }
     },
   }

--- a/test/services/github_actions.test.js
+++ b/test/services/github_actions.test.js
@@ -6,15 +6,34 @@ describe('GitHub Actions CI Provider', function() {
     expect(github_actions.detect()).toBe(true)
   })
 
-  it('can get GitHub Actions env info', function() {
-    process.env.GITHUB_SHA = '743b04806ea677403aa2ff26c6bdeb85005de658'
-    process.env.GITHUB_REPOSITORY = 'codecov/codecov-repo'
+  it('can get GitHub Actions env info on push event', function() {
     process.env.GITHUB_REF = 'refs/heads/master'
+    process.env.GITHUB_REPOSITORY = 'codecov/codecov-repo'
+    process.env.GITHUB_RUN_ID = '257701960'
+    process.env.GITHUB_SHA = '743b04806ea677403aa2ff26c6bdeb85005de658'
 
     expect(github_actions.configuration()).toEqual({
-      service: 'github-actions',
-      commit: '743b04806ea677403aa2ff26c6bdeb85005de658',
       branch: 'master',
+      build: '257701960',
+      commit: '743b04806ea677403aa2ff26c6bdeb85005de658',
+      service: 'github-actions',
+      slug: 'codecov/codecov-repo',
+    })
+  })
+
+  it('can get GitHub Actions env info on pull request', function() {
+    process.env.GITHUB_HEAD_REF = 'develop'
+    process.env.GITHUB_REF = 'refs/pull/7/merge'
+    process.env.GITHUB_REPOSITORY = 'codecov/codecov-repo'
+    process.env.GITHUB_RUN_ID = '257701960'
+    process.env.GITHUB_SHA = '743b04806ea677403aa2ff26c6bdeb85005de658'
+
+    expect(github_actions.configuration()).toEqual({
+      branch: 'develop',
+      build: '257701960',
+      commit: '743b04806ea677403aa2ff26c6bdeb85005de658',
+      pr: '7',
+      service: 'github-actions',
       slug: 'codecov/codecov-repo',
     })
   })

--- a/test/services/github_actions.test.js
+++ b/test/services/github_actions.test.js
@@ -2,7 +2,7 @@ var github_actions = require('../../lib/services/github_actions')
 
 describe('GitHub Actions CI Provider', function() {
   it('can detect GitHub Actions', function() {
-    process.env.GITHUB_ACTIONS = true
+    process.env.GITHUB_ACTIONS = '1'
     expect(github_actions.detect()).to.be(true)
   })
 

--- a/test/services/github_actions.test.js
+++ b/test/services/github_actions.test.js
@@ -7,6 +7,7 @@ describe('GitHub Actions CI Provider', function() {
   })
 
   it('can get GitHub Actions env info on push event', function() {
+    delete process.env.GITHUB_HEAD_REF
     process.env.GITHUB_REF = 'refs/heads/master'
     process.env.GITHUB_REPOSITORY = 'codecov/codecov-repo'
     process.env.GITHUB_RUN_ID = '257701960'

--- a/test/services/github_actions.test.js
+++ b/test/services/github_actions.test.js
@@ -12,7 +12,7 @@ describe('GitHub Actions CI Provider', function() {
     process.env.GITHUB_REF = 'refs/heads/master'
 
     expect(github_actions.configuration()).toEqual({
-      service: 'github_actions',
+      service: 'github-actions',
       commit: '743b04806ea677403aa2ff26c6bdeb85005de658',
       branch: 'master',
       slug: 'codecov/codecov-repo',

--- a/test/services/github_actions.test.js
+++ b/test/services/github_actions.test.js
@@ -1,4 +1,4 @@
-var github_actions = require('../../lib/services/github_actions')
+const github_actions = require('../../lib/services/github_actions')
 
 describe('GitHub Actions CI Provider', () => {
   it('can detect GitHub Actions', () => {

--- a/test/services/github_actions.test.js
+++ b/test/services/github_actions.test.js
@@ -1,12 +1,12 @@
-const github_actions = require('../../lib/services/github_actions')
+var github_actions = require('../../lib/services/github_actions')
 
-describe('GitHub Actions CI Provider', () => {
-  it('can detect GitHub Actions', () => {
+describe('GitHub Actions CI Provider', function() {
+  it('can detect GitHub Actions', function() {
     process.env.GITHUB_ACTIONS = true
     expect(github_actions.detect()).to.be(true)
   })
 
-  it('can get GitHub Actions env info', () => {
+  it('can get GitHub Actions env info', function() {
     process.env.GITHUB_SHA = '743b04806ea677403aa2ff26c6bdeb85005de658'
     process.env.GITHUB_REPOSITORY = 'codecov/codecov-repo'
     process.env.GITHUB_REF = 'refs/heads/master'

--- a/test/services/github_actions.test.js
+++ b/test/services/github_actions.test.js
@@ -3,7 +3,7 @@ var github_actions = require('../../lib/services/github_actions')
 describe('GitHub Actions CI Provider', function() {
   it('can detect GitHub Actions', function() {
     process.env.GITHUB_ACTIONS = '1'
-    expect(github_actions.detect()).to.be(true)
+    expect(github_actions.detect()).toBe(true)
   })
 
   it('can get GitHub Actions env info', function() {
@@ -11,7 +11,7 @@ describe('GitHub Actions CI Provider', function() {
     process.env.GITHUB_REPOSITORY = 'codecov/codecov-repo'
     process.env.GITHUB_REF = 'refs/heads/master'
 
-    expect(github_actions.configuration()).to.eql({
+    expect(github_actions.configuration()).toEqual({
       service: 'github_actions',
       commit: '743b04806ea677403aa2ff26c6bdeb85005de658',
       branch: 'master',

--- a/test/services/github_actions.test.js
+++ b/test/services/github_actions.test.js
@@ -1,0 +1,21 @@
+var github_actions = require('../../lib/services/github_actions')
+
+describe('GitHub Actions CI Provider', () => {
+  it('can detect GitHub Actions', () => {
+    process.env.GITHUB_ACTIONS = true
+    expect(github_actions.detect()).to.be(true)
+  })
+
+  it('can get GitHub Actions env info', () => {
+    process.env.GITHUB_SHA = '743b04806ea677403aa2ff26c6bdeb85005de658'
+    process.env.GITHUB_REPOSITORY = 'codecov/codecov-repo'
+    process.env.GITHUB_REF = 'refs/heads/master'
+
+    expect(github_actions.configuration()).to.eql({
+      service: 'github_actions',
+      commit: '743b04806ea677403aa2ff26c6bdeb85005de658',
+      branch: 'master',
+      slug: 'codecov/codecov-repo',
+    })
+  })
+})


### PR DESCRIPTION
# Purpose

Currently there's no way for the node uploader to detect Actions CI/CD pipelines. This PR adds support for it.

**Note**: There's currently no way to obtain a build_url or build number from the Actions environment variables. That's why they've been excluded in this PR. 