### PR TITLE
Change cirrus-ci to match backend

### DIFF
--- a/lib/services/cirrus.js
+++ b/lib/services/cirrus.js
@@ -5,7 +5,7 @@ module.exports = {
   configuration: function() {
     console.log('    Cirrus CI Detected')
     return {
-      service: 'cirrusci',
+      service: 'cirrus-ci',
       build: process.env.CIRRUS_BUILD_ID,
       job: process.env.CIRRUS_TASK_ID,
       commit: process.env.CIRRUS_CHANGE_IN_REPO,

--- a/test/services/cirrus.test.js
+++ b/test/services/cirrus.test.js
@@ -15,7 +15,7 @@ describe('Cirrus CI Provider', function() {
     process.env.CIRRUS_PR = 'blah'
     process.env.CIRRUS_REPO_FULL_NAME = 'owner/repo'
     expect(cirrus.configuration()).toEqual({
-      service: 'cirrusci',
+      service: 'cirrus-ci',
       commit: '5678',
       build: '1234.1',
       job: '1234.1',


### PR DESCRIPTION
When I created the whitelist entry for this service on the backend, I added a dash. It is faster to fix it here then there.