### PR TITLE
Verify source version before parsing PR

### DIFF
--- a/lib/services/codebuild.js
+++ b/lib/services/codebuild.js
@@ -26,7 +26,10 @@ module.exports = {
       return git.branch()
     }
     function detectPRNumber() {
-      if (process.env.CODEBUILD_WEBHOOK_HEAD_REF) {
+      if (
+        process.env.CODEBUILD_WEBHOOK_HEAD_REF &&
+        process.env.CODEBUILD_SOURCE_VERSION.startsWith('pr/')
+      ) {
         return process.env.CODEBUILD_SOURCE_VERSION.replace(/^pr\//, '')
       }
       return undefined

--- a/test/services/codebuild.test.js
+++ b/test/services/codebuild.test.js
@@ -55,7 +55,7 @@ describe('AWS CodeBuild Provider', function() {
     })
   })
 
-  it('Test build triggered via Github Webhook', function() {
+  it('Test PR build triggered via Github Webhook', function() {
     process.env.CODEBUILD_WEBHOOK_HEAD_REF = 'refs/heads/master'
     expect(codebuild.configuration()).toEqual({
       service: 'codebuild',
@@ -64,6 +64,21 @@ describe('AWS CodeBuild Provider', function() {
       commit: '39ec2418eca4c539d765574a1c68f3bd77e8c549',
       branch: 'master',
       pr: '1',
+      slug: 'my-org/my-project',
+    })
+  })
+
+  it('Test non-PR build triggered via Github Webhook', function() {
+    process.env.CODEBUILD_WEBHOOK_HEAD_REF = 'refs/heads/master'
+    process.env.CODEBUILD_SOURCE_VERSION =
+      '39ec2418eca4c539d765574a1c68f3bd77e8c549'
+    expect(codebuild.configuration()).toEqual({
+      service: 'codebuild',
+      build: 'my-project:e016b9d9-f2c8-4749-8373-7ca673b6d969',
+      job: 'my-project:e016b9d9-f2c8-4749-8373-7ca673b6d969',
+      commit: '39ec2418eca4c539d765574a1c68f3bd77e8c549',
+      branch: 'master',
+      pr: undefined,
       slug: 'my-org/my-project',
     })
   })


### PR DESCRIPTION
fixes https://github.com/codecov/codecov-node/issues/171

Non-PR hooks can trigger builds in which the CODEBUILD_SOURCE_VERSION
would be populated as the commit SHA. Our current logic dictates that
that commit SHA would be passed onto CodeCov as the PR number, which
would always be an invalid value.

This updates the logic so that it will ensure that the environment
variable being checked actually matches the "pr/" pattern before trying
to use it. If it does not, it will return undefined.