### PR TITLE
Fix broken gcov command

### DIFF
--- a/lib/codecov.js
+++ b/lib/codecov.js
@@ -556,6 +556,9 @@ var upload = function(args, on_success, on_failure) {
 }
 
 function sanitizeVar(arg) {
+  if (!arg) {
+    return ''
+  }
   return arg.replace(/&/g, '')
 }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -282,4 +282,10 @@ describe('Codecov', function() {
       'real  run unsafe  command'
     )
   })
+
+  it('gracefully sanitizes undefined', function() {
+    expect(function() {
+      codecov.sanitizeVar(undefined)
+    }).not.toThrow()
+  })
 })


### PR DESCRIPTION
The gcov command can't be generated if none of the gcov options are
given on the command line, since sanitizeVar() will throw an exception
when given 'undefined' as input. This runs sanitizeVar only if the
options are actually given.