### PR TITLE
Remove `'x-amz-acl': 'public-read'` header

### DIFF
--- a/lib/codecov.js
+++ b/lib/codecov.js
@@ -211,7 +211,6 @@ var sendToCodecovV3 = function(
             body: upload_body,
             headers: {
               'Content-Type': 'text/plain',
-              'x-amz-acl': 'public-read',
             },
           },
           function(err) {


### PR DESCRIPTION
Codecov recently did some fundamental storage changes on its backend in an effort to greatly improve the reliability of our underlying storage systems. As a result the `X-Amz-Acl: public-read` header is no longer needed, and may result in 400 errors if used. 

You can see a similar fix in codecov-python that removes that header here: https://github.com/codecov/codecov-python/pull/253/files