### PR TITLE
Update readme with 400 error info

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,11 @@ nyc report --reporter=text-lcov > coverage.lcov
 ./node_modules/.bin/codecov
 ```
 
+## Troubleshooting
+
+If you're seeing an **HTTP 400 error when uploading reports to S3**, make sure you've updated to at least version 3.7.0. 
+
+
 ## Change Log
 
 - v2.0.0 No longer supports node v0.10 because of the execSync.


### PR DESCRIPTION
Latest release of codecov-node includes changes to resolve a specific 400 error while uploading to s3. This PR updates the readme to encourage users to make sure they have the latest version of the package if they encounter 400 errors during upload. 
While they could be running into 400 errors for an entirely different reason than those addressed in the latest release, updating and seeing if that resolved the issue is generally a good first step to try here.
Happy to change the wording around, just let me know what y'all would prefer.