### PR TITLE
Recover broken find pattern for UNIX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,4 @@ node_js:
 
 after_success:
   - ./bin/codecov -e TRAVIS_NODE_VERSION -f coverage/*.json
+  - ./bin/codecov -e TRAVIS_NODE_VERSION

--- a/README.md
+++ b/README.md
@@ -89,8 +89,7 @@ nyc report --reporter=text-lcov > coverage.lcov
 
 ## Troubleshooting
 
-If you're seeing an **HTTP 400 error when uploading reports to S3**, make sure you've updated to at least version 3.7.0. 
-
+If you're seeing an **HTTP 400 error when uploading reports to S3**, make sure you've updated to at least version 3.7.0.
 
 ## Change Log
 
@@ -116,5 +115,6 @@ If you're seeing an **HTTP 400 error when uploading reports to S3**, make sure y
 - v3.6.3 Fix for AWS Codebuild & package updates
 - v3.6.4 Fix Cirrus CI
 - v3.7.0 Remove the X-Amz-Acl: public-read header
+- v3.7.1 Move to execFileSync and security fixes
 
 .

--- a/lib/codecov.js
+++ b/lib/codecov.js
@@ -20,64 +20,66 @@ var isWindows =
 
 if (!isWindows) {
   patterns = (
-    "-type f -name '*coverage.*' " +
-    "-or -name 'nosetests.xml' " +
-    "-or -name 'jacoco*.xml' " +
-    "-or -name 'clover.xml' " +
-    "-or -name 'report.xml' " +
-    "-or -name 'cobertura.xml' " +
-    "-or -name 'luacov.report.out' " +
-    "-or -name 'lcov.info' " +
-    "-or -name '*.lcov' " +
-    "-or -name 'gcov.info' " +
-    "-or -name '*.gcov' " +
-    "-or -name '*.lst' " +
-    "-not -name '*.sh' " +
-    "-not -name '*.data' " +
-    "-not -name '*.py' " +
-    "-not -name '*.class' " +
-    "-not -name '*.xcconfig' " +
-    "-not -name 'Coverage.profdata' " +
-    "-not -name 'phpunit-code-coverage.xml' " +
-    "-not -name 'coverage.serialized' " +
-    "-not -name '*.pyc' " +
-    "-not -name '*.cfg' " +
-    "-not -name '*.egg' " +
-    "-not -name '*.whl' " +
-    "-not -name '*.html' " +
-    "-not -name '*.js' " +
-    "-not -name '*.cpp' " +
-    "-not -name 'coverage.jade' " +
-    "-not -name 'include.lst' " +
-    "-not -name 'inputFiles.lst' " +
-    "-not -name 'createdFiles.lst' " +
-    "-not -name 'coverage.html' " +
-    "-not -name 'scoverage.measurements.*' " +
-    "-not -name 'test_*_coverage.txt' " +
-    "-not -path '*/vendor/*' " +
-    "-not -path '*/htmlcov/*' " +
-    "-not -path '*/home/cainus/*' " +
-    "-not -path '*/virtualenv/*' " +
-    "-not -path '*/js/generated/coverage/*' " +
-    "-not -path '*/.virtualenv/*' " +
-    "-not -path '*/virtualenvs/*' " +
-    "-not -path '*/.virtualenvs/*' " +
-    "-not -path '*/.env/*' " +
-    "-not -path '*/.envs/*' " +
-    "-not -path '*/env/*' " +
-    "-not -path '*/envs/*' " +
-    "-not -path '*/.venv/*' " +
-    "-not -path '*/.venvs/*' " +
-    "-not -path '*/venv/*' " +
-    "-not -path '*/venvs/*' " +
-    "-not -path '*/.git/*' " +
-    "-not -path '*/.hg/*' " +
-    "-not -path '*/.tox/*' " +
-    "-not -path '*/__pycache__/*' " +
-    "-not -path '*/.egg-info*' " +
-    "-not -path '*/$bower_components/*' " +
-    "-not -path '*/node_modules/*' " +
-    "-not -path '*/conftest_*.c.gcov'"
+    '-type f ( ' +
+    '-name *coverage.* ' +
+    '-or -name nosetests.xml ' +
+    '-or -name jacoco*.xml ' +
+    '-or -name clover.xml ' +
+    '-or -name report.xml ' +
+    '-or -name cobertura.xml ' +
+    '-or -name luacov.report.out ' +
+    '-or -name lcov.info ' +
+    '-or -name *.lcov ' +
+    '-or -name gcov.info ' +
+    '-or -name *.gcov ' +
+    '-or -name *.lst ' +
+    ') ' +
+    '-not -name *.sh ' +
+    '-not -name *.data ' +
+    '-not -name *.py ' +
+    '-not -name *.class ' +
+    '-not -name *.xcconfig ' +
+    '-not -name Coverage.profdata ' +
+    '-not -name phpunit-code-coverage.xml ' +
+    '-not -name coverage.serialized ' +
+    '-not -name *.pyc ' +
+    '-not -name *.cfg ' +
+    '-not -name *.egg ' +
+    '-not -name *.whl ' +
+    '-not -name *.html ' +
+    '-not -name *.js ' +
+    '-not -name *.cpp ' +
+    '-not -name coverage.jade ' +
+    '-not -name include.lst ' +
+    '-not -name inputFiles.lst ' +
+    '-not -name createdFiles.lst ' +
+    '-not -name coverage.html ' +
+    '-not -name scoverage.measurements.* ' +
+    '-not -name test_*_coverage.txt ' +
+    '-not -path */vendor/* ' +
+    '-not -path */htmlcov/* ' +
+    '-not -path */home/cainus/* ' +
+    '-not -path */virtualenv/* ' +
+    '-not -path */js/generated/coverage/* ' +
+    '-not -path */.virtualenv/* ' +
+    '-not -path */virtualenvs/* ' +
+    '-not -path */.virtualenvs/* ' +
+    '-not -path */.env/* ' +
+    '-not -path */.envs/* ' +
+    '-not -path */env/* ' +
+    '-not -path */envs/* ' +
+    '-not -path */.venv/* ' +
+    '-not -path */.venvs/* ' +
+    '-not -path */venv/* ' +
+    '-not -path */venvs/* ' +
+    '-not -path */.git/* ' +
+    '-not -path */.hg/* ' +
+    '-not -path */.tox/* ' +
+    '-not -path */__pycache__/* ' +
+    '-not -path */.egg-info* ' +
+    '-not -path */$bower_components/* ' +
+    '-not -path */node_modules/* ' +
+    '-not -path */conftest_*.c.gcov'
   ).split(' ')
 } else {
   winPatterns = (

--- a/lib/codecov.js
+++ b/lib/codecov.js
@@ -360,10 +360,11 @@ var upload = function(args, on_success, on_failure) {
   var root = path.resolve(args.options.root || query.root || '.')
   console.log('==> Building file structure')
   try {
-    upload +=
-      execFileSync('git', ['ls-files', '||', 'hg', 'locate'], { cwd: root })
-        .toString()
-        .trim() + '\n<<<<<< network\n'
+    var network = execFileSync('git', ['ls-files'], { cwd: root })
+    if (network === '') {
+      network = execFileSync('hg', ['locate'], { cwd: root })
+    }
+    upload += network.toString().trim() + '\n<<<<<< network\n'
   } catch (err) {
     // not a git/hg dir, emulating git/hg ignore behavior
     upload +=

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "codecov",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codecov",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "description": "Uploading report to Codecov: https://codecov.io",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
#180 makes `find` command change to run through `execFileSync()`. However, *it always returns empty result* because of the quote has over-included as the filename of search condition. So I removed quotes from conditions.

In addition, removing brackets from find arguments (a4cc565) has affected to the result of finding coverage files. This commit reverts brackets to get back the original search condition too.

Previously quotes and escaped-brackets are required to run command on the shell environment by `execSync()`, but no longer need them because of using `execFileSync()` that is disabled shell environment by default.

Fix #184.