### PR TITLE
Update node versions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [10.x, 12.x, 14.x]
 
     steps:
     - uses: actions/checkout@v1

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,9 @@ sudo: false
 
 node_js:
   - 'node'
-  - '11'
+  - '14'
+  - '12'
   - '10'
-  - '9'
-  - '8'
-  - '7'
-  - '6'
 
 after_success:
   - ./bin/codecov -e TRAVIS_NODE_VERSION -f coverage/*.json

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,8 @@
 environment:
   matrix:
-    - nodejs_version: '11'
+    - nodejs_version: '14'
+    - nodejs_version: '12'
     - nodejs_version: '10'
-    - nodejs_version: '9'
-    - nodejs_version: '8'
-    - nodejs_version: '7'
-    - nodejs_version: '6'
 
 max_jobs: 4
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   node:
-    version: 4
+    version: 14
 
 test:
   post:


### PR DESCRIPTION
Based off of https://nodejs.org/en/about/releases/

Will address mocking out the API calls in the tests in another PR (why appveyor is showing broken)