### PR TITLE
Migrate to GitHub-native Dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,6 +1,0 @@
-version: 1
-
-update_configs:
-  - package_manager: 'javascript'
-    directory: '/'
-    update_schedule: 'live'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: daily
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: daily


### PR DESCRIPTION
## Changes: 

- Remove the `dependabot-preview` configuration and instead use the new configuration file in the `.github` folder.
- Dependabot now searches for updates on working days (Monday-Friday), the live schedule is no longer possible with GitHub-native Dependabot.
- Dependabot now also checks for GitHub Action runner updates as well.

## Context:

The `dependabot-preview` functionality is now integrated into GitHub proper.
This pull request migrates this repository from the old `dependabot-preview` to the integrated Dependabot.

## Documentation:

https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates

## Benefits of migrating:

- You no longer need to have the `dependabot-preview` app installed for this repository.
- You do all configuration from within the `dependabot.yml` file, no need to go to the Dependabot website.
- You can now check for GitHub Action runner updates as well.
- Configuration is public.

## Drawbacks of migrating:

- You can only check for updates on working days the `live` schedule is no longer possible.
- You can not tell Dependabot to merge patches if the tests pass.
- Configuration is public.

## What to do after merging:

If you don't use `dependabot-preview` on other repositories, you can remove it from your installed apps.