### PR TITLE
Add coverage-final.json and bump to 3.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,22 @@
-### 3.8.1
+## 3.8.2
 
-#### Fixes
+### Fixes
+
+- # Add coverage-final.json as a possible coverage file during file lookup
+
+## 3.8.1
+
+### Fixes
 
 - [#246](https://github.com/codecov/codecov-node/pull/246) Revert "Bump teeny-request from 6.0.1 to 7.0.0"
 
-### 3.8.0
+## 3.8.0
 
-#### Features
+### Features
 
 - [#160](https://github.com/codecov/codecov-node/pull/160) Add Github Actions support
 
-#### Fixes
+### Fixes
 
 - [#173](https://github.com/codecov/codecov-node/pull/173) Fix broken gcov command
 - [#195](https://github.com/codecov/codecov-node/pull/195) Update Node testing versions
@@ -47,99 +53,99 @@
 - [#223](https://github.com/codecov/codecov-node/pull/223) Bump eslint from 7.9.0 to 7.10.0
 - [#224](https://github.com/codecov/codecov-node/pull/224) Bump teeny-request from 7.0.0 to 7.0.1
 
-### 3.7.2
+## 3.7.2
 
 - Fix issue with network and file finding
 
-### 3.7.1
+## 3.7.1
 
 - Move to execFileSync and security fixes
 
-### 3.7.0
+## 3.7.0
 
 - Remove the X-Amz-Acl: public-read header
 
-### 3.6.4
+## 3.6.4
 
 - Fix Cirrus CI
 
-### 3.6.3
+## 3.6.3
 
 - Fix for AWS Codebuild & package updates
 
-### 3.6.2
+## 3.6.2
 
 - Command line args sanitized fix
 
-### 3.6.1
+## 3.6.1
 
 - Fix for Semaphore
 
-### 3.6.0
+## 3.6.0
 
 - Added AWS CodeBuild and Semaphore2
 
-### 3.5.0
+## 3.5.0
 
 - Added TeamCity support
 
-### 3.4.0
+## 3.4.0
 
 - Added Heroku CI support
 
-### 3.3.0
+## 3.3.0
 
 - Added pipe with `--pipe`, `-l`
 
-### 3.2.0
+## 3.2.0
 
 - Added azure pipelines
   .
 
-### 3.1.0
+## 3.1.0
 
 - Custom yaml file. Allow codecov token from yml file.
 
-### 3.0.4
+## 3.0.4
 
 - Security fixes
 
-### 3.0.3
+## 3.0.3
 
 - Support non-git/hg root dirs
 
-### 3.0.2
+## 3.0.2
 
 - Security fixes
 
-### 3.0.1
+## 3.0.1
 
 - Security fixes
 
-### 3.0.0
+## 3.0.0
 
 - No longer supports node v0.12 because of new version of request
 
-### 2.3.0
+## 2.3.0
 
 - Added support for Windows. Updated dependencies.
 
-### 2.2.0
+## 2.2.0
 
 - Support for Jenkins Blue Ocean. Clean reports after upload. Fix for Gitlab.
 
-### 2.1.0
+## 2.1.0
 
 - Flags supported http://docs.codecov.io/docs/flags
 
-### 2.0.2
+## 2.0.2
 
 - Display correct version number in console.
 
-### 2.0.1
+## 2.0.1
 
 - Publish as latest instead of next.
 
-### 2.0.0
+## 2.0.0
 
 - No longer supports node v0.10 because of the execSync.

--- a/lib/codecov.js
+++ b/lib/codecov.js
@@ -22,17 +22,18 @@ if (!isWindows) {
   patterns = (
     '-type f ( ' +
     '-name *coverage.* ' +
-    '-or -name nosetests.xml ' +
-    '-or -name jacoco*.xml ' +
-    '-or -name clover.xml ' +
-    '-or -name report.xml ' +
-    '-or -name cobertura.xml ' +
-    '-or -name luacov.report.out ' +
-    '-or -name lcov.info ' +
-    '-or -name *.lcov ' +
-    '-or -name gcov.info ' +
     '-or -name *.gcov ' +
+    '-or -name *.lcov ' +
     '-or -name *.lst ' +
+    '-or -name clover.xml ' +
+    '-or -name cobertura.xml ' +
+    '-or -name coverage-final.json ' +
+    '-or -name gcov.info ' +
+    '-or -name jacoco*.xml ' +
+    '-or -name lcov.info ' +
+    '-or -name luacov.report.out ' +
+    '-or -name nosetests.xml ' +
+    '-or -name report.xml ' +
     ') ' +
     '-not -name *.sh ' +
     '-not -name *.data ' +
@@ -144,7 +145,7 @@ if (!isWindows) {
   ).split(' ')
 }
 
-var sendToCodecovV2 = function(
+var sendToCodecovV2 = function (
   codecov_endpoint,
   query,
   upload_body,
@@ -164,7 +165,7 @@ var sendToCodecovV2 = function(
         Accept: 'text/plain',
       },
     },
-    function(err, response) {
+    function (err, response) {
       if (err || response.statusCode !== 200) {
         console.log('    ' + (err || response.body))
         return response
@@ -179,7 +180,7 @@ var sendToCodecovV2 = function(
   )
 }
 
-var sendToCodecovV4 = function(
+var sendToCodecovV4 = function (
   codecov_endpoint,
   query,
   upload_body,
@@ -199,7 +200,7 @@ var sendToCodecovV4 = function(
         Accept: 'text/plain',
       },
     },
-    function(err, response, result) {
+    function (err, response, result) {
       if (err) {
         sendToCodecovV2(
           codecov_endpoint,
@@ -219,7 +220,7 @@ var sendToCodecovV4 = function(
               'Content-Type': 'text/plain',
             },
           },
-          function(err) {
+          function (err) {
             if (err) {
               sendToCodecovV2(
                 codecov_endpoint,
@@ -240,7 +241,7 @@ var sendToCodecovV4 = function(
   )
 }
 
-var upload = function(args, on_success, on_failure) {
+var upload = function (args, on_success, on_failure) {
   // Build query
   var codecov_endpoint =
     args.options.url ||
@@ -274,7 +275,7 @@ var upload = function(args, on_success, on_failure) {
     debug.push('disabled detect')
   }
 
-  query.yaml = [yamlFile, '.codecov.yml'].reduce(function(result, file) {
+  query.yaml = [yamlFile, '.codecov.yml'].reduce(function (result, file) {
     return (
       result ||
       (fs.existsSync(path.resolve(process.cwd(), file))
@@ -382,14 +383,14 @@ var upload = function(args, on_success, on_failure) {
         if (!isWindows) {
           gcg = gcg
             .split(' ')
-            .map(function(p) {
+            .map(function (p) {
               return "-not -path '" + p + "'"
             })
             .join(' ')
         } else {
           gcg = gcg
             .split(' ')
-            .map(function(p) {
+            .map(function (p) {
               return '^| findstr /i /v ' + p
             })
             .join(' ')
@@ -493,10 +494,7 @@ var upload = function(args, on_success, on_failure) {
       if (more_patterns) {
         _findArgs.concat(more_patterns)
       }
-      _files = execFileSync('find', _findArgs)
-        .toString()
-        .trim()
-        .split('\n')
+      _files = execFileSync('find', _findArgs).toString().trim().split('\n')
     } else {
       // @TODO support for a root directory
       // It's not straightforward due to the nature of the dir command
@@ -549,7 +547,7 @@ var upload = function(args, on_success, on_failure) {
         codecov_endpoint,
         query,
         upload,
-        function() {
+        function () {
           // remove files after Uploading
           if (args.options.clear) {
             for (var i = files.length - 1; i >= 0; i--) {
@@ -562,7 +560,7 @@ var upload = function(args, on_success, on_failure) {
             on_success.apply(this, arguments)
           }
         },
-        on_failure || function() {}
+        on_failure || function () {}
       )
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "codecov",
-  "version": "3.8.1",
+  "version": "3.8.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2851,7 +2851,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "har-schema": {
       "version": "2.0.0",
@@ -3261,6 +3262,7 @@
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-docker": "^2.0.0"
       }
@@ -5291,6 +5293,7 @@
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.1.tgz",
       "integrity": "sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "growly": "^1.3.0",
         "is-wsl": "^2.2.0",
@@ -5305,6 +5308,7 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
           "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -5314,6 +5318,7 @@
           "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
           "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "isexe": "^2.0.0"
           }
@@ -6172,7 +6177,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "signal-exit": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codecov",
-  "version": "3.8.1",
+  "version": "3.8.2",
   "description": "Uploading report to Codecov: https://codecov.io",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- Add `coverage-final.json` to the list of possible coverage files
  This is already done in the [bash uploader](https://github.com/codecov/codecov-bash/blob/master/codecov#L1308) and is a result of [this community post](https://community.codecov.io/t/different-results-when-using-the-node-package-compared-to-the-bash-script/2806/2)

- Clean up the README
- Alphabetize some of the patterns